### PR TITLE
fix(notes): add connection status indicator and reduce timeout

### DIFF
--- a/crates/myme-services/src/todo.rs
+++ b/crates/myme-services/src/todo.rs
@@ -82,7 +82,9 @@ impl TodoClient {
         let base_url = Url::parse(&config.base_url).context("Invalid base URL")?;
 
         #[allow(unused_mut)]
-        let mut builder = Client::builder().timeout(std::time::Duration::from_secs(30));
+        let mut builder = Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .connect_timeout(std::time::Duration::from_secs(3));
 
         // Only allow invalid certs in debug builds AND when explicitly configured
         #[cfg(debug_assertions)]

--- a/crates/myme-ui/qml/pages/NotePage.qml
+++ b/crates/myme-ui/qml/pages/NotePage.qml
@@ -401,14 +401,17 @@ Page {
                     width: connectedLabel.implicitWidth + Theme.spacingMd
                     height: connectedLabel.implicitHeight + Theme.spacingXs
                     radius: 4
-                    color: Theme.success + "20"
+                    color: noteModel.loading ? Theme.warning + "20" :
+                           noteModel.connected ? Theme.success + "20" : Theme.error + "20"
 
                     Label {
                         id: connectedLabel
                         anchors.centerIn: parent
-                        text: "● Godo API Connected"
+                        text: noteModel.loading ? "● Connecting..." :
+                              noteModel.connected ? "● Godo API Connected" : "● Godo API Disconnected"
                         font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.success
+                        color: noteModel.loading ? Theme.warning :
+                               noteModel.connected ? Theme.success : Theme.error
                     }
                 }
             }

--- a/crates/myme-ui/src/models/note_model.rs
+++ b/crates/myme-ui/src/models/note_model.rs
@@ -22,6 +22,7 @@ pub mod qobject {
         #[qobject]
         #[qml_element]
         #[qproperty(bool, loading)]
+        #[qproperty(bool, connected)]
         #[qproperty(QString, error_message)]
         type NoteModel = super::NoteModelRust;
 
@@ -78,6 +79,7 @@ enum OpState {
 #[derive(Default)]
 pub struct NoteModelRust {
     loading: bool,
+    connected: bool,
     error_message: QString,
     notes: Vec<Note>,
     client: Option<Arc<NoteClient>>,
@@ -298,11 +300,13 @@ impl qobject::NoteModel {
                         tracing::info!("Successfully fetched {} notes", notes.len());
                         self.as_mut().rust_mut().clear_error();
                         self.as_mut().rust_mut().notes = notes;
+                        self.as_mut().set_connected(true);
                         self.as_mut().notes_changed();
                     }
                     Err(e) => {
                         tracing::error!("Failed to fetch notes: {}", e);
                         self.as_mut().rust_mut().set_error(&format!("Failed to fetch notes: {}", e));
+                        self.as_mut().set_connected(false);
                         self.as_mut().error_occurred();
                     }
                 }


### PR DESCRIPTION
## Summary
- Add `connected` property to NoteModel for real-time API status tracking
- Update NotePage.qml status indicator to show dynamic state (Connecting/Connected/Disconnected)
- Reduce HTTP timeout from 30s to 5s with 3s connect timeout for faster failure detection

## Problem
The Notes page showed "Godo API Connected" even when the API was unavailable. When Godo wasn't running, users had to wait up to 30 seconds for the connection to fail.

## Test plan
- [ ] Build with `.\build-qt.ps1`
- [ ] Run app without Godo - should show "Disconnected" in red within 3-5 seconds
- [ ] Start Godo, click Retry - should show "Connecting...", then "Connected" in green

🤖 Generated with [Claude Code](https://claude.com/claude-code)