### PR TITLE
feat(devtools): add Text Chunker tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,18 @@ Default config is created automatically on first run. Configuration is loaded us
 - cxx-qt exposes Rust methods to QML using the **exact snake_case names** from Rust (no camelCase conversion)
 - In QML, always call invokable methods with snake_case: `model.check_auth()`, `model.fetch_repos()`, `model.poll_channel()` — not `checkAuth`, `fetchRepos`, or `pollChannel`
 
+### Dev Tools Page
+The Dev Tools page (`DevToolsPage.qml`) provides utility tools for developers:
+- **JWT Generator**: Generate and verify JSON Web Tokens
+- **Encoding Hub**: Encode/decode Base64, Hex, URL strings
+- **UUID Generator**: Generate UUIDs v1, v4, v5, v7
+- **JSON Toolkit**: Format, validate, minify, convert JSON
+- **Hash Generator**: Generate MD5, SHA-1, SHA-256, SHA-512 hashes
+- **Time Toolkit**: Parse timestamps, convert timezones
+- **Text Chunker**: Split large text into ≤10,000 char chunks for AI tools with character limits
+
+Tools follow a consistent pattern: add entry to `tools` array, create `Component`, register in `Loader` switch. QML-only tools (no Rust backend) are preferred for simple utilities.
+
 ## Important Files
 
 ### Core Infrastructure

--- a/crates/myme-ui/qml/Icons.qml
+++ b/crates/myme-ui/qml/Icons.qml
@@ -80,4 +80,9 @@ QtObject {
     readonly property string key: "\uebae"
     readonly property string lock: "\uebd1"
     readonly property string user: "\ueda0"
+
+    // Text & Documents
+    readonly property string scissors: "\uecb8"
+    readonly property string textT: "\ued5c"
+    readonly property string article: "\ue958"
 }


### PR DESCRIPTION
## Summary

- Add Text Chunker to Dev Tools page for splitting large text into copyable chunks
- Designed for pasting into AI tools with character limits (e.g., Copilot)
- Smart boundary detection: breaks at paragraphs, sentences, words (avoids mid-word cuts)
- Maximum chunk size: 10,000 characters

## Features

- **Two-column layout**: Input text on left, chunked output on right
- **Smart chunking algorithm**: Prioritizes paragraph breaks → line breaks → sentence ends → word breaks → hard cut
- **Character counting**: Shows total input chars and per-chunk counts
- **One-click copy**: Each chunk has a copy button with visual feedback ("Copied!" toast)
- **Performance optimized**: Debounced chunking (150ms) for large text input
- **Clear button**: Quick way to reset input

## Changes

| File | Change |
|------|--------|
| `DevToolsPage.qml` | Add `chunkerToolComponent` (~430 lines) |
| `Icons.qml` | Add `scissors`, `textT`, `article` icons |
| `CLAUDE.md` | Document Dev Tools page with all available tools |

## Test plan

- [ ] Navigate to Dev Tools → Text Chunker
- [ ] Paste text < 10,000 chars → Should show 1 chunk
- [ ] Paste text > 10,000 chars → Should split into multiple chunks
- [ ] Verify chunks break at natural boundaries (not mid-word)
- [ ] Click Copy on each chunk → Verify clipboard content
- [ ] Verify "Copied!" feedback appears and auto-dismisses
- [ ] Test with very large text (100KB+) → Verify no UI lag
- [ ] Clear input → Verify chunks reset to empty state

🤖 Generated with [Claude Code](https://claude.ai/code)