### PR TITLE
feat(pipeline): lead triage, prospect side panel, org notes persistence

### DIFF
--- a/crates/myme-integrations/src/northcloud.rs
+++ b/crates/myme-integrations/src/northcloud.rs
@@ -145,7 +145,8 @@ impl NorthCloudClient {
 }
 
 /// Build a multi-line prospect description from RFP metadata.
-pub fn build_rfp_description(rfp: &RfpData, url: &str) -> String {
+/// Does NOT include closing_date or source_url — those live in dedicated Prospect fields.
+pub fn build_rfp_description(rfp: &RfpData) -> String {
     let mut parts = Vec::new();
     if let Some(org) = &rfp.organization_name {
         if !org.is_empty() {
@@ -157,18 +158,10 @@ pub fn build_rfp_description(rfp: &RfpData, url: &str) -> String {
             parts.push(desc.clone());
         }
     }
-    if let Some(closing) = &rfp.closing_date {
-        if !closing.is_empty() {
-            parts.push(format!("Closing: {}", closing));
-        }
-    }
     if let Some(city) = &rfp.city {
         if !city.is_empty() {
             parts.push(format!("Location: {}", city));
         }
-    }
-    if !url.is_empty() {
-        parts.push(format!("Source: {}", url));
     }
     parts.join("\n")
 }
@@ -256,18 +249,19 @@ mod tests {
             city: Some("Ottawa".into()),
             ..Default::default()
         };
-        let result = build_rfp_description(&rfp, "https://example.com/rfp/1");
+        let result = build_rfp_description(&rfp);
         assert!(result.contains("Issuer: City of Ottawa"));
         assert!(result.contains("Web dev project"));
-        assert!(result.contains("Closing: 2026-04-01"));
         assert!(result.contains("Location: Ottawa"));
-        assert!(result.contains("Source: https://example.com/rfp/1"));
+        // closing date and source URL now live in dedicated Prospect fields
+        assert!(!result.contains("Closing:"));
+        assert!(!result.contains("Source:"));
     }
 
     #[test]
     fn build_rfp_description_minimal() {
         let rfp = RfpData::default();
-        let result = build_rfp_description(&rfp, "");
+        let result = build_rfp_description(&rfp);
         assert_eq!(result, "");
     }
 
@@ -278,7 +272,7 @@ mod tests {
             description: Some("A project".into()),
             ..Default::default()
         };
-        let result = build_rfp_description(&rfp, "");
+        let result = build_rfp_description(&rfp);
         assert!(!result.contains("Issuer:"));
         assert!(result.contains("A project"));
     }

--- a/crates/myme-organizations/src/models.rs
+++ b/crates/myme-organizations/src/models.rs
@@ -68,6 +68,8 @@ pub struct Prospect {
     pub contact_name: Option<String>,
     pub contact_email: Option<String>,
     pub contact_role: Option<String>,
+    pub source_url: Option<String>,
+    pub closing_date: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/crates/myme-organizations/src/store.rs
+++ b/crates/myme-organizations/src/store.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use crate::models::{Organization, Prospect, ProspectStage};
 
-const SCHEMA_VERSION: i32 = 1;
+const SCHEMA_VERSION: i32 = 2;
 
 /// Local SQLite storage for organizations and prospects
 pub struct OrganizationStore {
@@ -32,56 +32,74 @@ impl OrganizationStore {
             .optional()?
             .unwrap_or(0);
 
-        if version < SCHEMA_VERSION {
-            self.conn.execute_batch(
-                "BEGIN TRANSACTION;
+        if version < 1 {
+            // Fresh database: create all tables with current (v2) schema
+            self.conn
+                .execute_batch(
+                    "BEGIN TRANSACTION;
 
-                CREATE TABLE IF NOT EXISTS organizations (
-                    id TEXT PRIMARY KEY,
-                    name TEXT NOT NULL,
-                    description TEXT,
-                    website TEXT,
-                    contact_name TEXT,
-                    contact_email TEXT,
-                    contact_phone TEXT,
-                    contact_role TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL
-                );
+                    CREATE TABLE IF NOT EXISTS organizations (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        description TEXT,
+                        website TEXT,
+                        contact_name TEXT,
+                        contact_email TEXT,
+                        contact_phone TEXT,
+                        contact_role TEXT,
+                        notes TEXT,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL
+                    );
 
-                CREATE TABLE IF NOT EXISTS prospects (
-                    id TEXT PRIMARY KEY,
-                    organization_id TEXT NOT NULL,
-                    name TEXT NOT NULL,
-                    description TEXT,
-                    stage TEXT NOT NULL,
-                    value TEXT,
-                    contact_name TEXT,
-                    contact_email TEXT,
-                    contact_role TEXT,
-                    created_at TEXT NOT NULL,
-                    updated_at TEXT NOT NULL,
-                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
-                );
+                    CREATE TABLE IF NOT EXISTS prospects (
+                        id TEXT PRIMARY KEY,
+                        organization_id TEXT NOT NULL,
+                        name TEXT NOT NULL,
+                        description TEXT,
+                        stage TEXT NOT NULL,
+                        value TEXT,
+                        contact_name TEXT,
+                        contact_email TEXT,
+                        contact_role TEXT,
+                        source_url TEXT,
+                        closing_date TEXT,
+                        created_at TEXT NOT NULL,
+                        updated_at TEXT NOT NULL,
+                        FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                    );
 
-                CREATE TABLE IF NOT EXISTS organization_projects (
-                    organization_id TEXT NOT NULL,
-                    project_id TEXT NOT NULL,
-                    PRIMARY KEY (organization_id, project_id),
-                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
-                );
+                    CREATE TABLE IF NOT EXISTS organization_projects (
+                        organization_id TEXT NOT NULL,
+                        project_id TEXT NOT NULL,
+                        PRIMARY KEY (organization_id, project_id),
+                        FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                    );
 
-                CREATE INDEX IF NOT EXISTS idx_prospects_org ON prospects(organization_id);
-                CREATE INDEX IF NOT EXISTS idx_prospects_stage ON prospects(stage);
-                CREATE INDEX IF NOT EXISTS idx_org_projects_org ON organization_projects(organization_id);
-                CREATE INDEX IF NOT EXISTS idx_org_projects_proj ON organization_projects(project_id);
+                    CREATE INDEX IF NOT EXISTS idx_prospects_org ON prospects(organization_id);
+                    CREATE INDEX IF NOT EXISTS idx_prospects_stage ON prospects(stage);
+                    CREATE INDEX IF NOT EXISTS idx_org_projects_org ON organization_projects(organization_id);
+                    CREATE INDEX IF NOT EXISTS idx_org_projects_proj ON organization_projects(project_id);
 
-                DELETE FROM schema_version;
-                INSERT INTO schema_version (version) VALUES (1);
+                    DELETE FROM schema_version;
+                    INSERT INTO schema_version (version) VALUES (2);
 
-                COMMIT;",
-            )
-            .context("Failed to initialize schema")?;
+                    COMMIT;",
+                )
+                .context("Failed to initialize schema")?;
+        } else if version < 2 {
+            // Upgrade existing v1 database: add new columns
+            self.conn
+                .execute_batch(
+                    "BEGIN TRANSACTION;
+                    ALTER TABLE prospects ADD COLUMN source_url TEXT;
+                    ALTER TABLE prospects ADD COLUMN closing_date TEXT;
+                    ALTER TABLE organizations ADD COLUMN notes TEXT;
+                    DELETE FROM schema_version;
+                    INSERT INTO schema_version (version) VALUES (2);
+                    COMMIT;",
+                )
+                .context("Failed to migrate schema to v2")?;
         }
 
         Ok(())
@@ -184,6 +202,28 @@ impl OrganizationStore {
         Ok(())
     }
 
+    /// Get the notes for an organization. Returns empty string if none.
+    pub fn get_org_notes(&self, org_id: &str) -> Result<String> {
+        let notes: Option<String> = self
+            .conn
+            .query_row("SELECT notes FROM organizations WHERE id = ?1", [org_id], |row| {
+                row.get(0)
+            })
+            .optional()?
+            .flatten();
+        Ok(notes.unwrap_or_default())
+    }
+
+    /// Set the notes for an organization.
+    pub fn set_org_notes(&self, org_id: &str, notes: &str) -> Result<()> {
+        let now = chrono::Utc::now().to_rfc3339();
+        self.conn.execute(
+            "UPDATE organizations SET notes = ?1, updated_at = ?2 WHERE id = ?3",
+            params![notes, now, org_id],
+        )?;
+        Ok(())
+    }
+
     // =========== Prospects ===========
 
     /// Insert or update a prospect
@@ -191,8 +231,8 @@ impl OrganizationStore {
         let stage_str = serde_json::to_string(&prospect.stage)?;
 
         self.conn.execute(
-            "INSERT INTO prospects (id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+            "INSERT INTO prospects (id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, source_url, closing_date, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
              ON CONFLICT(id) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -201,6 +241,8 @@ impl OrganizationStore {
                 contact_name = excluded.contact_name,
                 contact_email = excluded.contact_email,
                 contact_role = excluded.contact_role,
+                source_url = excluded.source_url,
+                closing_date = excluded.closing_date,
                 updated_at = excluded.updated_at",
             params![
                 prospect.id,
@@ -212,6 +254,8 @@ impl OrganizationStore {
                 prospect.contact_name,
                 prospect.contact_email,
                 prospect.contact_role,
+                prospect.source_url,
+                prospect.closing_date,
                 prospect.created_at,
                 prospect.updated_at,
             ],
@@ -222,7 +266,7 @@ impl OrganizationStore {
     /// Get prospects for an organization
     pub fn list_prospects(&self, organization_id: &str) -> Result<Vec<Prospect>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, created_at, updated_at
+            "SELECT id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, source_url, closing_date, created_at, updated_at
              FROM prospects WHERE organization_id = ?1 ORDER BY created_at",
         )?;
 
@@ -250,8 +294,10 @@ impl OrganizationStore {
                     contact_name: row.get(6)?,
                     contact_email: row.get(7)?,
                     contact_role: row.get(8)?,
-                    created_at: row.get(9)?,
-                    updated_at: row.get(10)?,
+                    source_url: row.get(9)?,
+                    closing_date: row.get(10)?,
+                    created_at: row.get(11)?,
+                    updated_at: row.get(12)?,
                 })
             })?
             .collect::<Result<Vec<_>, _>>()?;
@@ -399,6 +445,8 @@ mod tests {
             contact_name: None,
             contact_email: None,
             contact_role: None,
+            source_url: None,
+            closing_date: None,
             created_at: "2026-03-02T00:00:00Z".to_string(),
             updated_at: "2026-03-02T00:00:00Z".to_string(),
         };
@@ -422,6 +470,8 @@ mod tests {
             contact_name: Some("Jane Doe".to_string()),
             contact_email: None,
             contact_role: None,
+            source_url: None,
+            closing_date: None,
             created_at: "2026-03-02T00:00:00Z".to_string(),
             updated_at: "2026-03-02T00:00:00Z".to_string(),
         };
@@ -445,6 +495,8 @@ mod tests {
             contact_name: None,
             contact_email: None,
             contact_role: None,
+            source_url: None,
+            closing_date: None,
             created_at: "2026-03-02T00:00:00Z".to_string(),
             updated_at: "2026-03-02T00:00:00Z".to_string(),
         };
@@ -471,6 +523,8 @@ mod tests {
                 contact_name: None,
                 contact_email: None,
                 contact_role: None,
+                source_url: None,
+                closing_date: None,
                 created_at: "2026-03-02T00:00:00Z".to_string(),
                 updated_at: "2026-03-02T00:00:00Z".to_string(),
             };
@@ -540,6 +594,8 @@ mod tests {
             contact_name: Some("Alice".to_string()),
             contact_email: Some("alice@example.com".to_string()),
             contact_role: Some("Manager".to_string()),
+            source_url: None,
+            closing_date: None,
             created_at: "2026-03-02T00:00:00Z".to_string(),
             updated_at: "2026-03-02T00:00:00Z".to_string(),
         };
@@ -566,6 +622,62 @@ mod tests {
         assert_eq!(prospects[0].contact_email.as_deref(), Some("bob@example.com"));
         assert_eq!(prospects[0].contact_role.as_deref(), Some("Director"));
         assert_eq!(prospects[0].updated_at, "2026-04-01T00:00:00Z");
+    }
+
+    #[test]
+    fn test_prospect_source_url_and_closing_date() {
+        let (store, _dir) = test_store();
+        store.upsert_organization(&test_org()).unwrap();
+        let prospect = Prospect {
+            id: "p-rfp".to_string(),
+            organization_id: "org-1".to_string(),
+            name: "Air Quality RFP".to_string(),
+            description: None,
+            stage: ProspectStage::Lead,
+            value: None,
+            contact_name: None,
+            contact_email: None,
+            contact_role: None,
+            source_url: Some("https://buyandsell.gc.ca/rfp/123".to_string()),
+            closing_date: Some("2026-04-10".to_string()),
+            created_at: "2026-03-03T00:00:00Z".to_string(),
+            updated_at: "2026-03-03T00:00:00Z".to_string(),
+        };
+        store.upsert_prospect(&prospect).unwrap();
+        let loaded = store.list_prospects("org-1").unwrap();
+        assert_eq!(loaded[0].source_url.as_deref(), Some("https://buyandsell.gc.ca/rfp/123"));
+        assert_eq!(loaded[0].closing_date.as_deref(), Some("2026-04-10"));
+    }
+
+    #[test]
+    fn test_org_notes_get_set() {
+        let (store, _dir) = test_store();
+        store.upsert_organization(&test_org()).unwrap();
+        assert_eq!(store.get_org_notes("org-1").unwrap(), "");
+        store.set_org_notes("org-1", "Follow up next week").unwrap();
+        assert_eq!(store.get_org_notes("org-1").unwrap(), "Follow up next week");
+        store.set_org_notes("org-1", "Updated notes").unwrap();
+        assert_eq!(store.get_org_notes("org-1").unwrap(), "Updated notes");
+    }
+
+    #[test]
+    fn test_schema_migration_v1_to_v2() {
+        let (store, _dir) = test_store();
+        let ver: i32 = store
+            .conn
+            .query_row("SELECT version FROM schema_version LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(ver, 2);
+        // Verify new columns exist by inserting a row using them
+        store.upsert_organization(&test_org()).unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO prospects (id, organization_id, name, stage, source_url, closing_date, created_at, updated_at)
+                 VALUES ('t', 'org-1', 'n', '\"lead\"', 'https://x.com', '2026-01-01', 'now', 'now')",
+                [],
+            )
+            .unwrap();
     }
 
     #[test]

--- a/crates/myme-organizations/src/store.rs
+++ b/crates/myme-organizations/src/store.rs
@@ -217,14 +217,27 @@ impl OrganizationStore {
     /// Set the notes for an organization.
     pub fn set_org_notes(&self, org_id: &str, notes: &str) -> Result<()> {
         let now = chrono::Utc::now().to_rfc3339();
-        self.conn.execute(
+        let rows = self.conn.execute(
             "UPDATE organizations SET notes = ?1, updated_at = ?2 WHERE id = ?3",
             params![notes, now, org_id],
         )?;
+        if rows == 0 {
+            anyhow::bail!("Organization '{}' not found", org_id);
+        }
         Ok(())
     }
 
     // =========== Prospects ===========
+
+    /// Check if a prospect with the given ID already exists.
+    pub fn prospect_exists(&self, id: &str) -> Result<bool> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM prospects WHERE id = ?1",
+            [id],
+            |row| row.get(0),
+        )?;
+        Ok(count > 0)
+    }
 
     /// Insert or update a prospect
     pub fn upsert_prospect(&self, prospect: &Prospect) -> Result<()> {
@@ -678,6 +691,39 @@ mod tests {
                 [],
             )
             .unwrap();
+    }
+
+    #[test]
+    fn test_set_org_notes_nonexistent_org_errors() {
+        let (store, _dir) = test_store();
+        let result = store.set_org_notes("no-such-org", "some notes");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_prospect_exists() {
+        let (store, _dir) = test_store();
+        store.upsert_organization(&test_org()).unwrap();
+        assert!(!store.prospect_exists("p-1").unwrap());
+        let prospect = Prospect {
+            id: "p-1".to_string(),
+            organization_id: "org-1".to_string(),
+            name: "Test".to_string(),
+            description: None,
+            stage: ProspectStage::Lead,
+            value: None,
+            contact_name: None,
+            contact_email: None,
+            contact_role: None,
+            source_url: None,
+            closing_date: None,
+            created_at: "2026-03-02T00:00:00Z".to_string(),
+            updated_at: "2026-03-02T00:00:00Z".to_string(),
+        };
+        store.upsert_prospect(&prospect).unwrap();
+        assert!(store.prospect_exists("p-1").unwrap());
+        assert!(!store.prospect_exists("p-2").unwrap());
     }
 
     #[test]

--- a/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+++ b/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
@@ -12,9 +12,47 @@ Page {
     required property string organizationName
 
     property int currentTab: 0
+    property int selectedProspectIndex: -1
 
     onCurrentTabChanged: {
         prospectModel.import_result = ""
+        if (currentTab === 2) {
+            notesArea.text = prospectModel.get_org_notes()
+        }
+    }
+
+    function daysUntil(dateStr) {
+        if (!dateStr || dateStr === "")
+            return -1
+        var parts = dateStr.split("-")
+        if (parts.length < 3)
+            return -1
+        var d = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]))
+        var today = new Date()
+        today.setHours(0, 0, 0, 0)
+        return Math.ceil((d - today) / 86400000)
+    }
+
+    function urgencyColor(days) {
+        if (days < 0)
+            return Theme.textSecondary
+        if (days <= 7)
+            return "#E57373"
+        if (days <= 21)
+            return "#FF8A65"
+        if (days <= 60)
+            return "#F59E0B"
+        return Theme.textSecondary
+    }
+
+    function urgencyLabel(days) {
+        if (days < 0)
+            return "Closed"
+        if (days === 0)
+            return "Closes today"
+        if (days === 1)
+            return "1 day left"
+        return days + " days left"
     }
 
     background: Rectangle {
@@ -264,176 +302,567 @@ Page {
                         }
                     }
 
-                    ScrollView {
+                    RowLayout {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        Layout.leftMargin: Theme.spacingMd
-                        Layout.rightMargin: Theme.spacingMd
-                        Layout.bottomMargin: Theme.spacingMd
-                        contentWidth: pipelineRow.implicitWidth
+                        spacing: 0
 
-                        RowLayout {
-                            id: pipelineRow
-                            spacing: Theme.spacingSm
-                            height: parent.height
+                        // Kanban scroll area
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            Layout.leftMargin: Theme.spacingMd
+                            Layout.rightMargin: detailPage.selectedProspectIndex >= 0 ? 0 : Theme.spacingMd
+                            Layout.bottomMargin: Theme.spacingMd
+                            contentWidth: pipelineRow.implicitWidth
+                            clip: true
 
-                            Repeater {
-                                model: detailPage.stages
+                            RowLayout {
+                                id: pipelineRow
+                                spacing: Theme.spacingSm
+                                height: parent.height
 
-                                // Stage column
-                                Rectangle {
-                                    Layout.preferredWidth: 220
-                                    Layout.fillHeight: true
-                                    color: Theme.isDark ? "#05ffffff" : "#03000000"
-                                    radius: Theme.cardRadius
-                                    border.color: Theme.cardBorderSubtle
-                                    border.width: 1
+                                Repeater {
+                                    model: detailPage.stages
 
-                                    ColumnLayout {
-                                        anchors.fill: parent
-                                        anchors.margins: Theme.spacingSm
-                                        spacing: Theme.spacingSm
+                                    // Stage column
+                                    Rectangle {
+                                        id: stageColumn
+                                        Layout.preferredWidth: modelData.key === "lead" ? 320 : 220
+                                        Layout.fillHeight: true
+                                        color: Theme.isDark ? "#05ffffff" : "#03000000"
+                                        radius: Theme.cardRadius
+                                        border.color: Theme.cardBorderSubtle
+                                        border.width: 1
 
-                                        // Stage header
-                                        RowLayout {
-                                            Layout.fillWidth: true
+                                        property string stageKey: modelData.key
+
+                                        ColumnLayout {
+                                            anchors.fill: parent
+                                            anchors.margins: Theme.spacingSm
                                             spacing: Theme.spacingSm
 
-                                            Rectangle {
-                                                width: 10
-                                                height: 10
-                                                radius: 5
-                                                color: modelData.color
-                                            }
-
-                                            Label {
-                                                text: modelData.label
-                                                font.family: Theme.fontFamily
-                                                font.pixelSize: Theme.fontSizeSmall
-                                                font.weight: Font.Bold
-                                                color: Theme.text
+                                            // Stage header
+                                            RowLayout {
                                                 Layout.fillWidth: true
+                                                spacing: Theme.spacingSm
+
+                                                Rectangle {
+                                                    width: 10
+                                                    height: 10
+                                                    radius: 5
+                                                    color: modelData.color
+                                                }
+
+                                                Label {
+                                                    text: modelData.label
+                                                    font.family: Theme.fontFamily
+                                                    font.pixelSize: Theme.fontSizeSmall
+                                                    font.weight: Font.Bold
+                                                    color: Theme.text
+                                                    Layout.fillWidth: true
+                                                }
+
+                                                Label {
+                                                    text: {
+                                                        void(prospectModel.prospect_revision);
+                                                        return prospectModel.count_for_stage(modelData.key);
+                                                    }
+                                                    font.family: Theme.fontFamily
+                                                    font.pixelSize: Theme.fontSizeSmall
+                                                    color: Theme.textSecondary
+                                                }
                                             }
 
-                                            Label {
-                                                text: { void(prospectModel.prospect_revision); return prospectModel.count_for_stage(modelData.key) }
-                                                font.family: Theme.fontFamily
-                                                font.pixelSize: Theme.fontSizeSmall
-                                                color: Theme.textSecondary
+                                            // Prospect cards
+                                            ListView {
+                                                Layout.fillWidth: true
+                                                Layout.fillHeight: true
+                                                clip: true
+                                                spacing: Theme.spacingXs
+
+                                                model: {
+                                                    void(prospectModel.prospect_revision);
+                                                    if (stageColumn.stageKey === "lead") {
+                                                        return JSON.parse(prospectModel.lead_prospects_by_urgency());
+                                                    }
+                                                    return JSON.parse(prospectModel.prospects_for_stage(stageColumn.stageKey));
+                                                }
+
+                                                delegate: Rectangle {
+                                                    id: prospectCard
+                                                    width: ListView.view.width
+                                                    height: cardContent.implicitHeight + Theme.spacingSm * 2
+                                                    radius: Theme.buttonRadius
+                                                    color: (detailPage.selectedProspectIndex === prospectIndex) ? (Theme.isDark ? "#20ffffff" : "#10000000") : (prospectMouse.containsMouse ? (Theme.isDark ? Qt.lighter(Theme.cardBg, 1.05) : Qt.darker(Theme.cardBg, 1.02)) : Theme.cardBg)
+                                                    border.color: (detailPage.selectedProspectIndex === prospectIndex) ? Theme.primary : Theme.cardBorderSubtle
+                                                    border.width: 1
+
+                                                    property int prospectIndex: modelData
+                                                    property bool isLead: stageColumn.stageKey === "lead"
+
+                                                    opacity: 0
+                                                    Component.onCompleted: prospectFade.start()
+                                                    SequentialAnimation {
+                                                        id: prospectFade
+                                                        PauseAnimation { duration: index * 30 }
+                                                        NumberAnimation { target: prospectCard; property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
+                                                    }
+
+                                                    ColumnLayout {
+                                                        id: cardContent
+                                                        anchors.left: parent.left
+                                                        anchors.right: parent.right
+                                                        anchors.top: parent.top
+                                                        anchors.margins: Theme.spacingSm
+                                                        spacing: 4
+
+                                                        // Urgency + budget row (Lead only)
+                                                        RowLayout {
+                                                            visible: prospectCard.isLead
+                                                            Layout.fillWidth: true
+                                                            spacing: Theme.spacingXs
+
+                                                            property int days: detailPage.daysUntil(prospectModel.get_prospect_closing_date(prospectIndex))
+
+                                                            Label {
+                                                                visible: parent.days >= 0
+                                                                text: detailPage.urgencyLabel(parent.parent.days)
+                                                                font.family: Theme.fontFamily
+                                                                font.pixelSize: 10
+                                                                font.weight: Font.Medium
+                                                                color: detailPage.urgencyColor(parent.parent.days)
+                                                            }
+
+                                                            Item { Layout.fillWidth: true }
+
+                                                            Label {
+                                                                visible: text !== ""
+                                                                text: prospectModel.get_prospect_value(prospectIndex)
+                                                                font.family: Theme.fontFamily
+                                                                font.pixelSize: 10
+                                                                font.weight: Font.Medium
+                                                                color: Theme.primary
+                                                            }
+                                                        }
+
+                                                        // Name
+                                                        Label {
+                                                            text: prospectModel.get_prospect_name(prospectIndex)
+                                                            font.family: Theme.fontFamily
+                                                            font.pixelSize: Theme.fontSizeSmall
+                                                            font.weight: Font.Medium
+                                                            color: Theme.text
+                                                            elide: Text.ElideRight
+                                                            maximumLineCount: prospectCard.isLead ? 2 : 1
+                                                            wrapMode: prospectCard.isLead ? Text.WordWrap : Text.NoWrap
+                                                            Layout.fillWidth: true
+                                                        }
+
+                                                        // Contact / org name
+                                                        Label {
+                                                            visible: text !== ""
+                                                            text: prospectModel.get_prospect_contact_name(prospectIndex)
+                                                            font.family: Theme.fontFamily
+                                                            font.pixelSize: 11
+                                                            color: Theme.textSecondary
+                                                            elide: Text.ElideRight
+                                                            Layout.fillWidth: true
+                                                        }
+
+                                                        // Lead quick-action buttons (show on hover)
+                                                        RowLayout {
+                                                            visible: prospectCard.isLead && prospectMouse.containsMouse
+                                                            Layout.fillWidth: true
+                                                            spacing: Theme.spacingXs
+
+                                                            Button {
+                                                                text: "Open RFP"
+                                                                visible: prospectModel.get_prospect_source_url(prospectIndex) !== ""
+                                                                font.family: Theme.fontFamily
+                                                                font.pixelSize: 10
+                                                                contentItem: Label { text: parent.text; font: parent.font; color: Theme.primary; horizontalAlignment: Text.AlignHCenter }
+                                                                background: Rectangle {
+                                                                    color: parent.hovered ? (Theme.isDark ? "#15ffffff" : "#08000000") : "transparent"
+                                                                    radius: Theme.buttonRadius
+                                                                    border.color: Theme.isDark ? "#15ffffff" : "#10000000"
+                                                                    border.width: 1
+                                                                    implicitHeight: 24
+                                                                }
+                                                                onClicked: Qt.openUrlExternally(prospectModel.get_prospect_source_url(prospectIndex))
+                                                            }
+
+                                                            Item { Layout.fillWidth: true }
+
+                                                            Button {
+                                                                text: "✓ Qualify"
+                                                                font.family: Theme.fontFamily
+                                                                font.pixelSize: 10
+                                                                contentItem: Label { text: parent.text; font: parent.font; color: "#5BB98C"; horizontalAlignment: Text.AlignHCenter }
+                                                                background: Rectangle {
+                                                                    color: parent.hovered ? "#155BB98C" : "transparent"
+                                                                    radius: Theme.buttonRadius
+                                                                    border.color: "#305BB98C"
+                                                                    border.width: 1
+                                                                    implicitHeight: 24
+                                                                    implicitWidth: 62
+                                                                }
+                                                                onClicked: {
+                                                                    if (detailPage.selectedProspectIndex === prospectIndex)
+                                                                        detailPage.selectedProspectIndex = -1;
+                                                                    prospectModel.move_prospect(prospectIndex, "qualified");
+                                                                }
+                                                            }
+
+                                                            Button {
+                                                                text: "✗ Skip"
+                                                                font.family: Theme.fontFamily
+                                                                font.pixelSize: 10
+                                                                contentItem: Label { text: parent.text; font: parent.font; color: "#E57373"; horizontalAlignment: Text.AlignHCenter }
+                                                                background: Rectangle {
+                                                                    color: parent.hovered ? "#15E57373" : "transparent"
+                                                                    radius: Theme.buttonRadius
+                                                                    border.color: "#30E57373"
+                                                                    border.width: 1
+                                                                    implicitHeight: 24
+                                                                    implicitWidth: 50
+                                                                }
+                                                                onClicked: {
+                                                                    if (detailPage.selectedProspectIndex === prospectIndex)
+                                                                        detailPage.selectedProspectIndex = -1;
+                                                                    prospectModel.move_prospect(prospectIndex, "lost");
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+
+                                                    MouseArea {
+                                                        id: prospectMouse
+                                                        anchors.fill: parent
+                                                        hoverEnabled: true
+                                                        cursorShape: Qt.PointingHandCursor
+                                                        onClicked: {
+                                                            if (detailPage.selectedProspectIndex === prospectIndex) {
+                                                                detailPage.selectedProspectIndex = -1;
+                                                            } else {
+                                                                detailPage.selectedProspectIndex = prospectIndex;
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+
+                                            // Add prospect button
+                                            Button {
+                                                Layout.fillWidth: true
+                                                contentItem: Label {
+                                                    text: "+ Add"
+                                                    font.family: Theme.fontFamily
+                                                    font.pixelSize: Theme.fontSizeSmall
+                                                    color: Theme.textSecondary
+                                                    horizontalAlignment: Text.AlignHCenter
+                                                }
+                                                background: Rectangle {
+                                                    color: parent.hovered ? Theme.surfaceAlt : "transparent"
+                                                    radius: Theme.buttonRadius
+                                                    border.color: Theme.isDark ? "#10ffffff" : "#10000000"
+                                                    border.width: 1
+                                                    implicitHeight: 32
+                                                }
+                                                onClicked: {
+                                                    addProspectStage = modelData.key;
+                                                    addProspectDialog.open();
+                                                }
                                             }
                                         }
+                                    }
+                                }
+                            }
+                        }
 
-                                        // Prospect cards
-                                        ListView {
-                                            Layout.fillWidth: true
-                                            Layout.fillHeight: true
-                                            clip: true
-                                            spacing: Theme.spacingXs
+                        // Prospect side panel
+                        Rectangle {
+                            id: sidePanel
+                            Layout.preferredWidth: 380
+                            Layout.fillHeight: true
+                            Layout.rightMargin: 0
+                            visible: detailPage.selectedProspectIndex >= 0
+                            color: Theme.isDark ? "#0affffff" : "#06000000"
+                            border.color: Theme.borderLight
+                            border.width: 1
 
-                                            model: {
-                                                void(prospectModel.prospect_revision);
-                                                const indices = JSON.parse(prospectModel.prospects_for_stage(modelData.key));
-                                                return indices;
-                                            }
+                            opacity: detailPage.selectedProspectIndex >= 0 ? 1 : 0
+                            Behavior on opacity { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
 
-                                            delegate: Rectangle {
-                                                id: prospectCard
-                                                width: ListView.view.width
-                                                height: prospectCardLayout.implicitHeight + Theme.spacingSm * 2
-                                                radius: Theme.buttonRadius
-                                                color: prospectMouse.containsMouse ? (Theme.isDark ? Qt.lighter(Theme.cardBg, 1.05) : Qt.darker(Theme.cardBg, 1.02)) : Theme.cardBg
-                                                border.color: Theme.cardBorderSubtle
-                                                border.width: 1
+                            ColumnLayout {
+                                anchors.fill: parent
+                                anchors.margins: Theme.spacingMd
+                                spacing: Theme.spacingMd
+                                visible: detailPage.selectedProspectIndex >= 0
 
-                                                property int prospectIndex: modelData
+                                // Name + close button
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
 
-                                                // Staggered animation
-                                                opacity: 0
-                                                Component.onCompleted: {
-                                                    console.log("[ProspectCard] index=" + index
-                                                        + " prospectIndex=" + prospectIndex
-                                                        + " name=" + prospectModel.get_prospect_name(prospectIndex)
-                                                        + " height=" + height
-                                                        + " implicitH=" + prospectCardLayout.implicitHeight)
-                                                    prospectFade.start()
-                                                }
-                                                SequentialAnimation {
-                                                    id: prospectFade
-                                                    PauseAnimation { duration: index * 30 }
-                                                    NumberAnimation { target: prospectCard; property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
-                                                }
+                                    Label {
+                                        text: prospectModel.get_prospect_name(detailPage.selectedProspectIndex)
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeNormal
+                                        font.weight: Font.Bold
+                                        color: Theme.text
+                                        wrapMode: Text.WordWrap
+                                        maximumLineCount: 2
+                                        elide: Text.ElideRight
+                                        Layout.fillWidth: true
+                                    }
 
-                                                ColumnLayout {
-                                                    id: prospectCardLayout
-                                                    anchors.left: parent.left
-                                                    anchors.right: parent.right
-                                                    anchors.top: parent.top
-                                                    anchors.margins: Theme.spacingSm
-                                                    spacing: Theme.spacingXxs
+                                    Button {
+                                        contentItem: Text {
+                                            text: Icons.x
+                                            font.family: Icons.family
+                                            font.pixelSize: 16
+                                            color: Theme.textSecondary
+                                            horizontalAlignment: Text.AlignHCenter
+                                        }
+                                        background: Rectangle {
+                                            color: parent.hovered ? (Theme.isDark ? "#10ffffff" : "#08000000") : "transparent"
+                                            radius: Theme.buttonRadius
+                                            implicitWidth: 28
+                                            implicitHeight: 28
+                                        }
+                                        onClicked: detailPage.selectedProspectIndex = -1
+                                    }
+                                }
 
-                                                    Label {
-                                                        text: prospectModel.get_prospect_name(prospectIndex)
-                                                        font.family: Theme.fontFamily
-                                                        font.pixelSize: Theme.fontSizeSmall
-                                                        font.weight: Font.Medium
-                                                        color: Theme.text
-                                                        elide: Text.ElideRight
-                                                        Layout.fillWidth: true
-                                                    }
+                                // Stage selector
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
 
-                                                    Label {
-                                                        visible: text !== ""
-                                                        text: prospectModel.get_prospect_value(prospectIndex)
-                                                        font.family: Theme.fontFamily
-                                                        font.pixelSize: 11
-                                                        color: Theme.primary
-                                                    }
+                                    Label {
+                                        text: "Stage"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.textSecondary
+                                        Layout.preferredWidth: 70
+                                    }
 
-                                                    Label {
-                                                        visible: text !== ""
-                                                        text: prospectModel.get_prospect_contact_name(prospectIndex)
-                                                        font.family: Theme.fontFamily
-                                                        font.pixelSize: 11
-                                                        color: Theme.textSecondary
-                                                        elide: Text.ElideRight
-                                                        Layout.fillWidth: true
-                                                    }
-                                                }
+                                    ComboBox {
+                                        id: stageCombo
+                                        Layout.fillWidth: true
+                                        model: ["Lead", "Qualified", "Contacted", "Proposal", "Negotiation", "Won", "Lost"]
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
 
-                                                MouseArea {
-                                                    id: prospectMouse
-                                                    anchors.fill: parent
-                                                    hoverEnabled: true
-                                                    cursorShape: Qt.PointingHandCursor
-                                                    onClicked: {
-                                                        editProspectIndex = prospectIndex;
-                                                        editProspectDialog.open();
-                                                    }
-                                                }
-                                            }
+                                        currentIndex: {
+                                            var s = prospectModel.get_prospect_stage(detailPage.selectedProspectIndex)
+                                            var idx = stageCombo.model.indexOf(s)
+                                            return idx >= 0 ? idx : 0
                                         }
 
-                                        // Add prospect button
-                                        Button {
-                                            Layout.fillWidth: true
-                                            contentItem: Label {
-                                                text: "+ Add"
-                                                font.family: Theme.fontFamily
-                                                font.pixelSize: Theme.fontSizeSmall
-                                                color: Theme.textSecondary
-                                                horizontalAlignment: Text.AlignHCenter
-                                            }
-                                            background: Rectangle {
-                                                color: parent.hovered ? Theme.surfaceAlt : "transparent"
-                                                radius: Theme.buttonRadius
-                                                border.color: Theme.isDark ? "#10ffffff" : "#10000000"
-                                                border.width: 1
-                                                implicitHeight: 32
-                                            }
-                                            onClicked: {
-                                                addProspectStage = modelData.key;
-                                                addProspectDialog.open();
-                                            }
+                                        contentItem: Label {
+                                            leftPadding: 8
+                                            text: stageCombo.displayText
+                                            font: stageCombo.font
+                                            color: Theme.text
+                                            verticalAlignment: Text.AlignVCenter
+                                        }
+
+                                        background: Rectangle {
+                                            color: Theme.surfaceAlt
+                                            radius: Theme.buttonRadius
+                                            border.color: stageCombo.popup.visible ? Theme.primary : Theme.borderLight
+                                            border.width: 1
+                                            implicitHeight: 32
+                                        }
+
+                                        onActivated: {
+                                            var stageKey = currentText.toLowerCase()
+                                            prospectModel.move_prospect(detailPage.selectedProspectIndex, stageKey)
+                                        }
+                                    }
+                                }
+
+                                // Closing date with urgency
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
+                                    visible: prospectModel.get_prospect_closing_date(detailPage.selectedProspectIndex) !== ""
+
+                                    property string closingDate: prospectModel.get_prospect_closing_date(detailPage.selectedProspectIndex)
+                                    property int days: detailPage.daysUntil(closingDate)
+
+                                    Label {
+                                        text: "Closing"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.textSecondary
+                                        Layout.preferredWidth: 70
+                                    }
+
+                                    ColumnLayout {
+                                        spacing: 2
+                                        Label {
+                                            text: parent.parent.closingDate
+                                            font.family: Theme.fontFamily
+                                            font.pixelSize: Theme.fontSizeSmall
+                                            color: Theme.text
+                                        }
+                                        Label {
+                                            visible: parent.parent.days >= 0
+                                            text: "● " + detailPage.urgencyLabel(parent.parent.days)
+                                            font.family: Theme.fontFamily
+                                            font.pixelSize: 11
+                                            color: detailPage.urgencyColor(parent.parent.days)
+                                        }
+                                    }
+                                }
+
+                                // Budget
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
+                                    visible: prospectModel.get_prospect_value(detailPage.selectedProspectIndex) !== ""
+
+                                    Label {
+                                        text: "Budget"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.textSecondary
+                                        Layout.preferredWidth: 70
+                                    }
+
+                                    Label {
+                                        text: prospectModel.get_prospect_value(detailPage.selectedProspectIndex)
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        font.weight: Font.Medium
+                                        color: Theme.primary
+                                    }
+                                }
+
+                                // Contact
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
+                                    visible: prospectModel.get_prospect_contact_name(detailPage.selectedProspectIndex) !== ""
+
+                                    Label {
+                                        text: "Contact"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.textSecondary
+                                        Layout.preferredWidth: 70
+                                    }
+
+                                    Label {
+                                        text: prospectModel.get_prospect_contact_name(detailPage.selectedProspectIndex)
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.text
+                                        Layout.fillWidth: true
+                                        elide: Text.ElideRight
+                                    }
+                                }
+
+                                // Email
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
+                                    visible: prospectModel.get_prospect_contact_email(detailPage.selectedProspectIndex) !== ""
+
+                                    Label {
+                                        text: "Email"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.textSecondary
+                                        Layout.preferredWidth: 70
+                                    }
+
+                                    Label {
+                                        text: prospectModel.get_prospect_contact_email(detailPage.selectedProspectIndex)
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.primary
+                                        Layout.fillWidth: true
+                                        elide: Text.ElideRight
+                                    }
+                                }
+
+                                // Open Source RFP button
+                                Button {
+                                    visible: prospectModel.get_prospect_source_url(detailPage.selectedProspectIndex) !== ""
+                                    Layout.fillWidth: true
+                                    contentItem: Label {
+                                        text: "Open Source RFP →"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.primaryText
+                                        horizontalAlignment: Text.AlignHCenter
+                                    }
+                                    background: Rectangle {
+                                        color: parent.hovered ? Theme.primaryHover : Theme.primary
+                                        radius: Theme.buttonRadius
+                                        implicitHeight: 36
+                                    }
+                                    onClicked: Qt.openUrlExternally(prospectModel.get_prospect_source_url(detailPage.selectedProspectIndex))
+                                }
+
+                                // Description
+                                Label {
+                                    visible: prospectModel.get_prospect_description(detailPage.selectedProspectIndex) !== ""
+                                    text: "Description"
+                                    font.family: Theme.fontFamily
+                                    font.pixelSize: Theme.fontSizeSmall
+                                    font.weight: Font.Bold
+                                    color: Theme.textSecondary
+                                }
+
+                                ScrollView {
+                                    visible: prospectModel.get_prospect_description(detailPage.selectedProspectIndex) !== ""
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                    clip: true
+
+                                    Label {
+                                        width: parent.width
+                                        text: prospectModel.get_prospect_description(detailPage.selectedProspectIndex)
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.text
+                                        wrapMode: Text.WordWrap
+                                    }
+                                }
+
+                                // Edit + Delete row
+                                RowLayout {
+                                    Layout.fillWidth: true
+                                    spacing: Theme.spacingSm
+
+                                    Button {
+                                        text: "Edit"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        contentItem: Label { text: parent.text; font: parent.font; color: Theme.primaryText; horizontalAlignment: Text.AlignHCenter }
+                                        background: Rectangle { color: parent.hovered ? Theme.primaryHover : Theme.primary; radius: Theme.buttonRadius; implicitHeight: 32; implicitWidth: 70 }
+                                        onClicked: {
+                                            editProspectIndex = detailPage.selectedProspectIndex;
+                                            editProspectDialog.open();
+                                        }
+                                    }
+
+                                    Item { Layout.fillWidth: true }
+
+                                    Button {
+                                        text: "Delete"
+                                        font.family: Theme.fontFamily
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        contentItem: Label { text: parent.text; font: parent.font; color: "#E57373"; horizontalAlignment: Text.AlignHCenter }
+                                        background: Rectangle { color: parent.hovered ? "#20E57373" : "transparent"; radius: Theme.buttonRadius; implicitHeight: 32 }
+                                        onClicked: {
+                                            prospectModel.delete_prospect(detailPage.selectedProspectIndex);
+                                            detailPage.selectedProspectIndex = -1;
                                         }
                                     }
                                 }
@@ -581,21 +1010,12 @@ Page {
                         color: Theme.text
                     }
 
-                    Label {
-                        text: "Notes persistence coming soon. Notes typed here will not be saved."
-                        font.family: Theme.fontFamily
-                        font.pixelSize: Theme.fontSizeSmall
-                        color: Theme.primary
-                        opacity: 0.8
-                    }
-
                     ScrollView {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
 
                         TextArea {
                             id: notesArea
-                            text: ""
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeNormal
                             color: Theme.text
@@ -608,8 +1028,17 @@ Page {
                                 border.color: notesArea.activeFocus ? Theme.primary : (Theme.isDark ? "#10ffffff" : "#10000000")
                                 border.width: 1
                             }
+
+                            onTextChanged: notesDebounce.restart()
                         }
                     }
+                }
+
+                Timer {
+                    id: notesDebounce
+                    interval: 500
+                    repeat: false
+                    onTriggered: prospectModel.set_org_notes(notesArea.text)
                 }
             }
         }
@@ -977,7 +1406,11 @@ Page {
         }
     }
 
+    focus: true
+    Keys.onEscapePressed: selectedProspectIndex = -1
+
     Component.onCompleted: {
         prospectModel.load_prospects(detailPage.organizationId);
+        notesArea.text = prospectModel.get_org_notes();
     }
 }

--- a/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+++ b/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
@@ -28,6 +28,8 @@ Page {
         if (parts.length < 3)
             return -1
         var d = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]))
+        if (isNaN(d.getTime()))
+            return -1
         var today = new Date()
         today.setHours(0, 0, 0, 0)
         return Math.ceil((d - today) / 86400000)
@@ -383,10 +385,14 @@ Page {
 
                                                 model: {
                                                     void(prospectModel.prospect_revision);
-                                                    if (stageColumn.stageKey === "lead") {
-                                                        return JSON.parse(prospectModel.lead_prospects_by_urgency());
+                                                    try {
+                                                        if (stageColumn.stageKey === "lead") {
+                                                            return JSON.parse(prospectModel.lead_prospects_by_urgency());
+                                                        }
+                                                        return JSON.parse(prospectModel.prospects_for_stage(stageColumn.stageKey));
+                                                    } catch (e) {
+                                                        return [];
                                                     }
-                                                    return JSON.parse(prospectModel.prospects_for_stage(stageColumn.stageKey));
                                                 }
 
                                                 delegate: Rectangle {
@@ -427,11 +433,11 @@ Page {
 
                                                             Label {
                                                                 visible: parent.days >= 0
-                                                                text: detailPage.urgencyLabel(parent.parent.days)
+                                                                text: detailPage.urgencyLabel(parent.days)
                                                                 font.family: Theme.fontFamily
                                                                 font.pixelSize: 10
                                                                 font.weight: Font.Medium
-                                                                color: detailPage.urgencyColor(parent.parent.days)
+                                                                color: detailPage.urgencyColor(parent.days)
                                                             }
 
                                                             Item { Layout.fillWidth: true }
@@ -921,8 +927,11 @@ Page {
                         spacing: Theme.spacingSm
 
                         model: {
-                            const projects = JSON.parse(prospectModel.linked_projects());
-                            return projects;
+                            try {
+                                return JSON.parse(prospectModel.linked_projects());
+                            } catch (e) {
+                                return [];
+                            }
                         }
 
                         delegate: Rectangle {
@@ -1411,6 +1420,5 @@ Page {
 
     Component.onCompleted: {
         prospectModel.load_prospects(detailPage.organizationId);
-        notesArea.text = prospectModel.get_org_notes();
     }
 }

--- a/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+++ b/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
@@ -33,12 +33,8 @@ Page {
         onTriggered: prospectModel.poll_channel()
     }
 
-    Connections {
-        target: prospectModel
-        function onProspects_changed() {
-            prospectModel.prospect_count(); // trigger UI refresh
-        }
-    }
+    // prospect_revision is a QProperty counter that increments on every change,
+    // allowing QML bindings that read it to re-evaluate automatically.
 
     // Pipeline stage definitions
     readonly property var stages: [
@@ -320,7 +316,7 @@ Page {
                                             }
 
                                             Label {
-                                                text: prospectModel.count_for_stage(modelData.key)
+                                                text: { void(prospectModel.prospect_revision); return prospectModel.count_for_stage(modelData.key) }
                                                 font.family: Theme.fontFamily
                                                 font.pixelSize: Theme.fontSizeSmall
                                                 color: Theme.textSecondary
@@ -335,11 +331,13 @@ Page {
                                             spacing: Theme.spacingXs
 
                                             model: {
+                                                void(prospectModel.prospect_revision);
                                                 const indices = JSON.parse(prospectModel.prospects_for_stage(modelData.key));
                                                 return indices;
                                             }
 
                                             delegate: Rectangle {
+                                                id: prospectCard
                                                 width: ListView.view.width
                                                 height: prospectCardLayout.implicitHeight + Theme.spacingSm * 2
                                                 radius: Theme.buttonRadius
@@ -351,11 +349,18 @@ Page {
 
                                                 // Staggered animation
                                                 opacity: 0
-                                                Component.onCompleted: prospectFade.start()
+                                                Component.onCompleted: {
+                                                    console.log("[ProspectCard] index=" + index
+                                                        + " prospectIndex=" + prospectIndex
+                                                        + " name=" + prospectModel.get_prospect_name(prospectIndex)
+                                                        + " height=" + height
+                                                        + " implicitH=" + prospectCardLayout.implicitHeight)
+                                                    prospectFade.start()
+                                                }
                                                 SequentialAnimation {
                                                     id: prospectFade
                                                     PauseAnimation { duration: index * 30 }
-                                                    NumberAnimation { target: parent; property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
+                                                    NumberAnimation { target: prospectCard; property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
                                                 }
 
                                                 ColumnLayout {

--- a/crates/myme-ui/src/models/prospect_model.rs
+++ b/crates/myme-ui/src/models/prospect_model.rs
@@ -368,6 +368,8 @@ impl qobject::ProspectModel {
             contact_name: opt_string(contact_name),
             contact_email: opt_string(contact_email),
             contact_role: opt_string(contact_role),
+            source_url: None,
+            closing_date: None,
             created_at: now.clone(),
             updated_at: now,
         };
@@ -435,6 +437,8 @@ impl qobject::ProspectModel {
             contact_name: opt_string(contact_name),
             contact_email: opt_string(contact_email),
             contact_role: opt_string(contact_role),
+            source_url: existing.source_url,
+            closing_date: existing.closing_date,
             created_at: existing.created_at,
             updated_at: now,
         };

--- a/crates/myme-ui/src/models/prospect_model.rs
+++ b/crates/myme-ui/src/models/prospect_model.rs
@@ -338,7 +338,10 @@ impl qobject::ProspectModel {
         }
         let store = match &self.rust().organization_store {
             Some(s) => s,
-            None => return QString::from(""),
+            None => {
+                tracing::warn!("get_org_notes: store not initialized");
+                return QString::from("");
+            }
         };
         match store.lock().get_org_notes(&org_id) {
             Ok(notes) => QString::from(notes.as_str()),
@@ -352,16 +355,20 @@ impl qobject::ProspectModel {
     pub fn set_org_notes(mut self: Pin<&mut Self>, notes: &QString) {
         let org_id = self.as_ref().rust().organization_id.to_string();
         if org_id.is_empty() {
+            tracing::warn!("set_org_notes: organization_id not set");
             return;
         }
         let store = match &self.as_ref().rust().organization_store {
             Some(s) => s.clone(),
-            None => return,
+            None => {
+                tracing::warn!("set_org_notes: store not initialized");
+                return;
+            }
         };
         if let Err(e) = store.lock().set_org_notes(&org_id, &notes.to_string()) {
             tracing::error!("Failed to save org notes: {}", e);
             self.as_mut()
-                .set_error_message(QString::from(format!("Failed to save notes: {}", e)));
+                .set_error_message(QString::from(myme_core::AppError::from(e).user_message()));
         }
     }
 
@@ -591,7 +598,10 @@ impl qobject::ProspectModel {
         }
         let store = match &self.rust().organization_store {
             Some(s) => s,
-            None => return QString::from("[]"),
+            None => {
+                tracing::warn!("linked_projects: store not initialized");
+                return QString::from("[]");
+            }
         };
         let store_guard = store.lock();
         match store_guard.list_linked_projects(&org_id) {

--- a/crates/myme-ui/src/models/prospect_model.rs
+++ b/crates/myme-ui/src/models/prospect_model.rs
@@ -21,6 +21,7 @@ pub mod qobject {
         #[qproperty(QString, error_message)]
         #[qproperty(QString, organization_id)]
         #[qproperty(QString, import_result)]
+        #[qproperty(i32, prospect_revision)]
         type ProspectModel = super::ProspectModelRust;
 
         #[qinvokable]
@@ -120,6 +121,7 @@ pub struct ProspectModelRust {
     error_message: QString,
     organization_id: QString,
     import_result: QString,
+    prospect_revision: i32,
     prospects: Vec<Prospect>,
     organization_store: Option<Arc<parking_lot::Mutex<OrganizationStore>>>,
 }
@@ -166,6 +168,13 @@ fn parse_stage(s: &str) -> ProspectStage {
 }
 
 impl qobject::ProspectModel {
+    /// Bump revision counter (triggers QML binding re-evaluation) and emit signal.
+    fn notify_prospects_changed(mut self: Pin<&mut Self>) {
+        let rev = *self.as_ref().prospect_revision();
+        self.as_mut().set_prospect_revision(rev + 1);
+        self.as_mut().prospects_changed();
+    }
+
     pub fn load_prospects(mut self: Pin<&mut Self>, organization_id: &QString) {
         self.as_mut().rust_mut().ensure_initialized();
         self.as_mut().set_organization_id(organization_id.clone());
@@ -190,7 +199,7 @@ impl qobject::ProspectModel {
                 drop(store_guard);
                 self.as_mut().rust_mut().prospects = prospects;
                 self.as_mut().set_loading(false);
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to load prospects: {}", e);
@@ -308,7 +317,7 @@ impl qobject::ProspectModel {
             Ok(()) => {
                 drop(store_guard);
                 self.as_mut().rust_mut().prospects[index as usize].stage = stage;
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
                 tracing::info!("Moved prospect {} to stage {:?}", prospect_id, stage);
             }
             Err(e) => {
@@ -369,7 +378,7 @@ impl qobject::ProspectModel {
                 drop(store_guard);
                 tracing::info!("Created prospect: {}", prospect.name);
                 self.as_mut().rust_mut().prospects.push(prospect);
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to create prospect: {}", e);
@@ -436,7 +445,7 @@ impl qobject::ProspectModel {
                 drop(store_guard);
                 tracing::info!("Updated prospect: {}", updated.name);
                 self.as_mut().rust_mut().prospects[index as usize] = updated;
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to update prospect: {}", e);
@@ -470,7 +479,7 @@ impl qobject::ProspectModel {
                 tracing::info!("Deleted prospect: {}", prospect_id);
                 drop(store_guard);
                 self.as_mut().rust_mut().prospects.remove(index as usize);
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to delete prospect: {}", e);
@@ -524,7 +533,7 @@ impl qobject::ProspectModel {
             Ok(()) => {
                 drop(store_guard);
                 tracing::info!("Linked project {} to org {}", project_id_str, org_id);
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to link project: {}", e);
@@ -556,7 +565,7 @@ impl qobject::ProspectModel {
             Ok(()) => {
                 drop(store_guard);
                 tracing::info!("Unlinked project {} from org {}", project_id_str, org_id);
-                self.as_mut().prospects_changed();
+                self.as_mut().notify_prospects_changed();
             }
             Err(e) => {
                 tracing::error!("Failed to unlink project: {}", e);
@@ -580,7 +589,7 @@ impl qobject::ProspectModel {
                 match result {
                     Ok((counts, prospects)) => {
                         self.as_mut().rust_mut().prospects = prospects;
-                        self.as_mut().prospects_changed();
+                        self.as_mut().notify_prospects_changed();
 
                         let result_json = serde_json::json!({
                             "imported": counts.imported,

--- a/crates/myme-ui/src/models/prospect_model.rs
+++ b/crates/myme-ui/src/models/prospect_model.rs
@@ -54,6 +54,24 @@ pub mod qobject {
         #[qinvokable]
         fn get_prospect_created_at(self: &ProspectModel, index: i32) -> QString;
 
+        #[qinvokable]
+        fn get_prospect_source_url(self: &ProspectModel, index: i32) -> QString;
+
+        #[qinvokable]
+        fn get_prospect_closing_date(self: &ProspectModel, index: i32) -> QString;
+
+        /// Returns JSON array of indices for Lead prospects sorted by closing_date ascending (nulls last).
+        #[qinvokable]
+        fn lead_prospects_by_urgency(self: &ProspectModel) -> QString;
+
+        /// Get notes for the current organization.
+        #[qinvokable]
+        fn get_org_notes(self: &ProspectModel) -> QString;
+
+        /// Save notes for the current organization.
+        #[qinvokable]
+        fn set_org_notes(self: Pin<&mut ProspectModel>, notes: &QString);
+
         /// Returns JSON array of indices for prospects in the given stage
         #[qinvokable]
         fn prospects_for_stage(self: &ProspectModel, stage: &QString) -> QString;
@@ -273,6 +291,78 @@ impl qobject::ProspectModel {
             .get_prospect(index)
             .map(|p| QString::from(&p.created_at))
             .unwrap_or_else(|| QString::from(""))
+    }
+
+    pub fn get_prospect_source_url(&self, index: i32) -> QString {
+        self.rust()
+            .get_prospect(index)
+            .and_then(|p| p.source_url.as_ref())
+            .map(|u| QString::from(u.as_str()))
+            .unwrap_or_else(|| QString::from(""))
+    }
+
+    pub fn get_prospect_closing_date(&self, index: i32) -> QString {
+        self.rust()
+            .get_prospect(index)
+            .and_then(|p| p.closing_date.as_ref())
+            .map(|d| QString::from(d.as_str()))
+            .unwrap_or_else(|| QString::from(""))
+    }
+
+    pub fn lead_prospects_by_urgency(&self) -> QString {
+        let mut lead_indices: Vec<(usize, Option<String>)> = self
+            .rust()
+            .prospects
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| p.stage == ProspectStage::Lead)
+            .map(|(i, p)| (i, p.closing_date.clone()))
+            .collect();
+
+        lead_indices.sort_by(|(_, a_date), (_, b_date)| match (a_date, b_date) {
+            (Some(a), Some(b)) => a.cmp(b),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        });
+
+        let indices: Vec<i32> = lead_indices.into_iter().map(|(i, _)| i as i32).collect();
+        let json = serde_json::to_string(&indices).unwrap_or_else(|_| "[]".to_string());
+        QString::from(&json)
+    }
+
+    pub fn get_org_notes(&self) -> QString {
+        let org_id = self.rust().organization_id.to_string();
+        if org_id.is_empty() {
+            return QString::from("");
+        }
+        let store = match &self.rust().organization_store {
+            Some(s) => s,
+            None => return QString::from(""),
+        };
+        match store.lock().get_org_notes(&org_id) {
+            Ok(notes) => QString::from(notes.as_str()),
+            Err(e) => {
+                tracing::error!("Failed to get org notes: {}", e);
+                QString::from("")
+            }
+        }
+    }
+
+    pub fn set_org_notes(mut self: Pin<&mut Self>, notes: &QString) {
+        let org_id = self.as_ref().rust().organization_id.to_string();
+        if org_id.is_empty() {
+            return;
+        }
+        let store = match &self.as_ref().rust().organization_store {
+            Some(s) => s.clone(),
+            None => return,
+        };
+        if let Err(e) = store.lock().set_org_notes(&org_id, &notes.to_string()) {
+            tracing::error!("Failed to save org notes: {}", e);
+            self.as_mut()
+                .set_error_message(QString::from(format!("Failed to save notes: {}", e)));
+        }
     }
 
     pub fn prospects_for_stage(&self, stage: &QString) -> QString {

--- a/crates/myme-ui/src/services/organization_service.rs
+++ b/crates/myme-ui/src/services/organization_service.rs
@@ -104,7 +104,7 @@ async fn do_import_rfp_leads(
 
     let now = chrono::Utc::now().to_rfc3339();
     let mut imported = 0i32;
-    let skipped = 0i32;
+    let mut skipped = 0i32;
     let mut failed = 0i32;
 
     let store_guard = store.lock();
@@ -156,8 +156,15 @@ async fn do_import_rfp_leads(
             has_rfp_metadata,
         );
 
+        let already_exists = store_guard.prospect_exists(&prospect.id).unwrap_or(false);
         match store_guard.upsert_prospect(&prospect) {
-            Ok(_) => imported += 1,
+            Ok(_) => {
+                if already_exists {
+                    skipped += 1;
+                } else {
+                    imported += 1;
+                }
+            }
             Err(e) => {
                 tracing::error!("Failed to upsert prospect '{}': {}", prospect.name, e);
                 failed += 1;

--- a/crates/myme-ui/src/services/organization_service.rs
+++ b/crates/myme-ui/src/services/organization_service.rs
@@ -119,19 +119,15 @@ async fn do_import_rfp_leads(
             .unwrap_or(&hit.title)
             .to_string();
 
-        // Build description from RFP metadata or fall back to hit-level data
+        // Build description from RFP metadata or fall back to snippet
         let description = if let Some(r) = rfp {
-            build_rfp_description(r, &hit.url)
+            build_rfp_description(r)
         } else {
-            let mut parts = Vec::new();
-            parts.push(format!("Source: {} — {}", hit.source_name, hit.url));
-            if let Some(snippet) = &hit.snippet {
-                if !snippet.is_empty() {
-                    parts.push(snippet.clone());
-                }
-            }
-            parts.join("\n")
+            hit.snippet.clone().unwrap_or_default()
         };
+
+        let source_url = Some(hit.url.clone());
+        let closing_date = rfp.and_then(|r| r.closing_date.clone());
 
         let value = rfp.map(|r| rfp_budget_string(r)).unwrap_or_default();
         let contact_name = rfp.and_then(|r| r.organization_name.clone()).unwrap_or_default();
@@ -147,6 +143,8 @@ async fn do_import_rfp_leads(
             contact_name: if contact_name.is_empty() { None } else { Some(contact_name) },
             contact_email: if contact_email.is_empty() { None } else { Some(contact_email) },
             contact_role: None,
+            source_url,
+            closing_date,
             created_at: now.clone(),
             updated_at: now.clone(),
         };

--- a/crates/myme-ui/src/services/organization_service.rs
+++ b/crates/myme-ui/src/services/organization_service.rs
@@ -79,6 +79,8 @@ async fn do_import_rfp_leads(
     let config = myme_core::Config::load_cached();
     let base_url = config.northcloud.base_url.clone();
 
+    tracing::info!("RFP import: fetching from {} for org {}", base_url, org_id);
+
     let client =
         NorthCloudClient::new(&base_url).map_err(|e| OrganizationError::Network(e.to_string()))?;
 
@@ -91,36 +93,55 @@ async fn do_import_rfp_leads(
     let response =
         client.search_rfps(&params).await.map_err(|e| OrganizationError::Network(e.to_string()))?;
 
+    tracing::info!(
+        "RFP import: API returned {} hits (total_hits: {})",
+        response.hits.len(),
+        response.total_hits
+    );
+
     let store = crate::app_services::organization_store_or_init()
         .ok_or(OrganizationError::NotInitialized)?;
 
     let now = chrono::Utc::now().to_rfc3339();
     let mut imported = 0i32;
-    let mut skipped = 0i32;
+    let skipped = 0i32;
     let mut failed = 0i32;
 
     let store_guard = store.lock();
     for hit in &response.hits {
-        let rfp = match &hit.rfp {
-            Some(r) => r,
-            None => {
-                skipped += 1;
-                continue;
+        let has_rfp_metadata = hit.rfp.is_some();
+        let rfp = hit.rfp.as_ref();
+
+        // Use RFP metadata title if available, otherwise fall back to hit title
+        let name = rfp
+            .and_then(|r| r.title.as_deref())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&hit.title)
+            .to_string();
+
+        // Build description from RFP metadata or fall back to hit-level data
+        let description = if let Some(r) = rfp {
+            build_rfp_description(r, &hit.url)
+        } else {
+            let mut parts = Vec::new();
+            parts.push(format!("Source: {} — {}", hit.source_name, hit.url));
+            if let Some(snippet) = &hit.snippet {
+                if !snippet.is_empty() {
+                    parts.push(snippet.clone());
+                }
             }
+            parts.join("\n")
         };
 
-        let name = rfp.title.as_deref().filter(|s| !s.is_empty()).unwrap_or(&hit.title).to_string();
-
-        let description = build_rfp_description(rfp, &hit.url);
-        let value = rfp_budget_string(rfp);
-        let contact_name = rfp.organization_name.clone().unwrap_or_default();
-        let contact_email = rfp.contact_email.clone().unwrap_or_default();
+        let value = rfp.map(|r| rfp_budget_string(r)).unwrap_or_default();
+        let contact_name = rfp.and_then(|r| r.organization_name.clone()).unwrap_or_default();
+        let contact_email = rfp.and_then(|r| r.contact_email.clone()).unwrap_or_default();
 
         let prospect = Prospect {
             id: format!("nc-{}", hit.id),
             organization_id: org_id.to_string(),
             name,
-            description: Some(description),
+            description: if description.is_empty() { None } else { Some(description) },
             stage: ProspectStage::Lead,
             value: if value.is_empty() { None } else { Some(value) },
             contact_name: if contact_name.is_empty() { None } else { Some(contact_name) },
@@ -129,6 +150,13 @@ async fn do_import_rfp_leads(
             created_at: now.clone(),
             updated_at: now.clone(),
         };
+
+        tracing::info!(
+            "RFP import: processing hit '{}' (id={}, has_rfp_metadata={})",
+            prospect.name,
+            hit.id,
+            has_rfp_metadata,
+        );
 
         match store_guard.upsert_prospect(&prospect) {
             Ok(_) => imported += 1,
@@ -145,6 +173,13 @@ async fn do_import_rfp_leads(
         .map_err(|e| OrganizationError::Database(e.to_string()))?;
 
     drop(store_guard);
+
+    tracing::info!(
+        "RFP import complete: {} imported, {} skipped, {} failed",
+        imported,
+        skipped,
+        failed,
+    );
 
     Ok((RfpImportResult { imported, skipped, failed }, prospects))
 }

--- a/docs/plans/2026-03-03-pipeline-ux-design.md
+++ b/docs/plans/2026-03-03-pipeline-ux-design.md
@@ -1,0 +1,161 @@
+# Pipeline UX — Lead Triage & Prospect Detail Design
+
+**Date:** 2026-03-03
+**Status:** Approved
+
+## Problem
+
+The Pipeline kanban has leads but is not actionable:
+- No way to change a prospect's stage (kanban is read-only)
+- No closing date or source URL visible on cards — the two most important RFP signals
+- Closing date and source URL are buried as freeform text in description instead of proper fields
+- Edit dialog is a modal — too slow for triage
+- Notes tab doesn't persist
+
+## Goal
+
+Make the pipeline useable for converting RFP leads to money. Optimised for someone new to BD: show the key signals at a glance, make the next action (open the RFP) one click, and make stage changes fast.
+
+## Design
+
+### Section 1: Data Model
+
+**`myme-organizations` — Prospect struct:**
+
+Add two new optional fields:
+```rust
+pub source_url: Option<String>,
+pub closing_date: Option<String>,  // ISO 8601 date string e.g. "2026-04-01"
+```
+
+SQLite migration (additive, safe):
+```sql
+ALTER TABLE prospects ADD COLUMN source_url TEXT;
+ALTER TABLE prospects ADD COLUMN closing_date TEXT;
+```
+
+**`myme-organizations` — Organization notes:**
+
+Add `notes` TEXT column to `organizations` table:
+```sql
+ALTER TABLE organizations ADD COLUMN notes TEXT;
+```
+
+Add `get_notes(org_id)` and `set_notes(org_id, notes)` to `OrganizationStore`.
+
+**`myme-integrations` — RFP import:**
+
+`build_rfp_description` stops embedding "Source: ..." and "Closing: ..." lines.
+Import populates `prospect.source_url` and `prospect.closing_date` from `RfpData` directly.
+
+**`myme-ui` Rust bridge — new invokables on ProspectModel:**
+- `get_prospect_source_url(index: i32) -> QString`
+- `get_prospect_closing_date(index: i32) -> QString`
+- `sort_prospects_by_closing_date()` — sorts in-memory Vec ascending, nulls last
+- `update_prospect_stage(index: i32, stage: &QString)` — saves stage change immediately
+
+**`myme-ui` Rust bridge — new invokables on OrganizationModel:**
+- `get_org_notes(org_id: &QString) -> QString`
+- `set_org_notes(org_id: &QString, notes: &QString)`
+
+---
+
+### Section 2: Lead Triage List
+
+The Lead column is wider (320px vs 220px for other columns) and sorted by closing date ascending (soonest first, nulls at bottom).
+
+**Card layout (Lead column only):**
+```
+┌────────────────────────────────────────┐
+│ ● 3 days left          $45,000–$80,000 │  ← urgency badge + budget
+│ Canadian Air and Precipitation Monit.. │  ← name (2 lines max)
+│ Dept. of Environment (ECCC)            │  ← contact/org name
+│                                        │
+│ [🔗 Open RFP]  [✓ Qualify]  [✗ Skip]  │  ← action row (always visible)
+└────────────────────────────────────────┘
+```
+
+**Urgency color coding on days-left badge:**
+- Red (`#E57373`): ≤7 days
+- Orange (`#FF8A65`): 8–21 days
+- Yellow (`#F59E0B`): 22–60 days
+- Grey (textSecondary): no closing date or >60 days
+
+**Quick actions:**
+- **Open RFP** — `Qt.openUrlExternally(sourceUrl)`, opens in system browser
+- **Qualify →** — calls `update_prospect_stage(index, "qualified")`, card leaves Lead
+- **Skip** — calls `update_prospect_stage(index, "lost")`, card leaves Lead
+
+Other stage columns keep the existing 220px card layout (name + value + contact, click to open side panel).
+
+---
+
+### Section 3: Prospect Side Panel
+
+Clicking a card (except action buttons) opens a side panel sliding in from the right. Works for all stages.
+
+**Layout:** The Pipeline tab splits horizontally — kanban scrolls left, panel is fixed 380px on the right. Slides in with 200ms ease animation. Closes on Escape or clicking outside.
+
+```
+┌─────────────────────────────┬──────────────────────────────┐
+│  Kanban (scrollable)        │  Prospect name (2 lines)     │
+│                             │  ──────────────────────────  │
+│                             │  Stage: [Lead ▾]             │
+│                             │                              │
+│                             │  Closing   Mar 6, 2026       │
+│                             │            ● 3 days left     │
+│                             │  Budget    $45,000–$80,000   │
+│                             │  Contact   Dept. of Env.     │
+│                             │  Email     rfp@eccc.gc.ca    │
+│                             │                              │
+│                             │  [🔗 Open Source RFP →]      │
+│                             │                              │
+│                             │  Description                 │
+│                             │  ┌──────────────────────┐    │
+│                             │  │ Scrollable read-only  │    │
+│                             │  │ RFP text              │    │
+│                             │  └──────────────────────┘    │
+│                             │                              │
+│                             │  [Edit]        [Delete]      │
+└─────────────────────────────┴──────────────────────────────┘
+```
+
+**Stage ComboBox:** Shows current stage, all 7 options. Selecting a new value calls `update_prospect_stage` immediately — no Save button.
+
+**Open Source RFP button:** Primary CTA. Calls `Qt.openUrlExternally(sourceUrl)`. Hidden if sourceUrl is empty.
+
+**Edit button:** Opens the existing edit dialog (name, description, value, contact fields).
+
+---
+
+### Section 4: Stage Change & Notes Persistence
+
+**Two mechanisms for stage change:**
+1. Card quick actions on Lead column ("Qualify →", "Skip") — one-click, no panel
+2. Side panel ComboBox for all stages — full 7-stage selector, saves immediately
+
+**"Skip" behavior:** Sets stage to `lost`. Does not delete the prospect — recoverable.
+
+**Notes tab persistence:**
+- Org notes stored in `organizations.notes` TEXT column
+- `TextArea` loads notes via `get_org_notes()` on tab open
+- Saves via `set_org_notes()` debounced 500ms on text change
+
+---
+
+## Out of Scope
+
+- Drag-and-drop between kanban columns
+- Lead scoring / ranking algorithm
+- Email compose from contact email
+- Filter chips / search within leads
+- Multi-organization bulk actions
+
+## Files Affected
+
+| Layer | Files |
+|---|---|
+| `myme-organizations` | `store.rs` (migration + notes methods), `lib.rs` (Prospect fields) |
+| `myme-integrations` | `northcloud.rs` (populate source_url, closing_date; remove from description) |
+| `myme-ui` Rust | `prospect_model.rs` (new invokables), `organization_model.rs` (org notes) |
+| QML | `OrganizationDetailPage.qml` (Pipeline redesign + notes persistence) |

--- a/docs/plans/2026-03-03-pipeline-ux-implementation.md
+++ b/docs/plans/2026-03-03-pipeline-ux-implementation.md
@@ -1,0 +1,1493 @@
+# Pipeline UX Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the prospect pipeline actionable — richer Lead cards with urgency signals, a slide-in side panel with stage change, and org notes persistence.
+
+**Architecture:** Four-layer change: (1) DB schema migration adds `source_url`/`closing_date` to `prospects` and `notes` to `organizations`; (2) integrations layer stops embedding these in description text; (3) Rust bridge gets new read invokables + org-notes methods; (4) QML Pipeline tab redesigned with wider Lead column, urgency badges, quick-action buttons, and a 380px side panel.
+
+**Tech Stack:** Rust, rusqlite, cxx-qt, QML (Qt 6)
+
+---
+
+### Task 1: DB migration + Prospect struct fields
+
+**Files:**
+- Modify: `crates/myme-organizations/src/models.rs`
+- Modify: `crates/myme-organizations/src/store.rs`
+
+**Step 1: Write failing test for new Prospect fields round-trip**
+
+Add to the `#[cfg(test)]` block in `store.rs`:
+
+```rust
+#[test]
+fn test_prospect_source_url_and_closing_date() {
+    let (store, _dir) = test_store();
+    store.upsert_organization(&test_org()).unwrap();
+    let prospect = Prospect {
+        id: "p-rfp".to_string(),
+        organization_id: "org-1".to_string(),
+        name: "Air Quality RFP".to_string(),
+        description: None,
+        stage: ProspectStage::Lead,
+        value: None,
+        contact_name: None,
+        contact_email: None,
+        contact_role: None,
+        source_url: Some("https://buyandsell.gc.ca/rfp/123".to_string()),
+        closing_date: Some("2026-04-10".to_string()),
+        created_at: "2026-03-03T00:00:00Z".to_string(),
+        updated_at: "2026-03-03T00:00:00Z".to_string(),
+    };
+    store.upsert_prospect(&prospect).unwrap();
+    let loaded = store.list_prospects("org-1").unwrap();
+    assert_eq!(loaded[0].source_url.as_deref(), Some("https://buyandsell.gc.ca/rfp/123"));
+    assert_eq!(loaded[0].closing_date.as_deref(), Some("2026-04-10"));
+}
+
+#[test]
+fn test_org_notes_get_set() {
+    let (store, _dir) = test_store();
+    store.upsert_organization(&test_org()).unwrap();
+    // defaults to empty
+    assert_eq!(store.get_org_notes("org-1").unwrap(), "");
+    // set and retrieve
+    store.set_org_notes("org-1", "Follow up next week").unwrap();
+    assert_eq!(store.get_org_notes("org-1").unwrap(), "Follow up next week");
+    // overwrite
+    store.set_org_notes("org-1", "Updated notes").unwrap();
+    assert_eq!(store.get_org_notes("org-1").unwrap(), "Updated notes");
+}
+
+#[test]
+fn test_schema_migration_v1_to_v2() {
+    // Verifies that a fresh store lands on v2 and has the new columns
+    let (store, _dir) = test_store();
+    let ver: i32 = store.conn.query_row(
+        "SELECT version FROM schema_version LIMIT 1",
+        [],
+        |r| r.get(0),
+    ).unwrap();
+    assert_eq!(ver, 2);
+    // new columns exist — insert would fail if they didn't
+    store.conn.execute(
+        "INSERT INTO prospects (id, organization_id, name, stage, source_url, closing_date, created_at, updated_at)
+         VALUES ('t', 'x', 'n', '\"lead\"', 'https://x.com', '2026-01-01', 'now', 'now')",
+        [],
+    ).unwrap();
+}
+```
+
+**Step 2: Run tests to see them fail**
+
+```bash
+cd /home/fsd42/dev/myme
+cargo test -p myme-organizations -- test_prospect_source_url test_org_notes test_schema_migration 2>&1 | tail -20
+```
+
+Expected: compile errors — `Prospect` has no `source_url` field yet.
+
+**Step 3: Add fields to `Prospect` in `models.rs`**
+
+In `crates/myme-organizations/src/models.rs`, after `contact_role`:
+
+```rust
+pub struct Prospect {
+    pub id: String,
+    pub organization_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub stage: ProspectStage,
+    pub value: Option<String>,
+    pub contact_name: Option<String>,
+    pub contact_email: Option<String>,
+    pub contact_role: Option<String>,
+    pub source_url: Option<String>,      // NEW: direct link to the RFP source
+    pub closing_date: Option<String>,    // NEW: ISO 8601 date e.g. "2026-04-10"
+    pub created_at: String,
+    pub updated_at: String,
+}
+```
+
+**Step 4: Update `init_schema` in `store.rs`**
+
+Replace `const SCHEMA_VERSION: i32 = 1;` with `const SCHEMA_VERSION: i32 = 2;`.
+
+Replace the entire `init_schema` method:
+
+```rust
+fn init_schema(&self) -> Result<()> {
+    self.conn
+        .execute("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)", [])?;
+
+    let version: i32 = self
+        .conn
+        .query_row("SELECT version FROM schema_version LIMIT 1", [], |row| row.get(0))
+        .optional()?
+        .unwrap_or(0);
+
+    if version < 1 {
+        // Fresh database: create all tables with current (v2) schema
+        self.conn
+            .execute_batch(
+                "BEGIN TRANSACTION;
+
+                CREATE TABLE IF NOT EXISTS organizations (
+                    id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    website TEXT,
+                    contact_name TEXT,
+                    contact_email TEXT,
+                    contact_phone TEXT,
+                    contact_role TEXT,
+                    notes TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS prospects (
+                    id TEXT PRIMARY KEY,
+                    organization_id TEXT NOT NULL,
+                    name TEXT NOT NULL,
+                    description TEXT,
+                    stage TEXT NOT NULL,
+                    value TEXT,
+                    contact_name TEXT,
+                    contact_email TEXT,
+                    contact_role TEXT,
+                    source_url TEXT,
+                    closing_date TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+
+                CREATE TABLE IF NOT EXISTS organization_projects (
+                    organization_id TEXT NOT NULL,
+                    project_id TEXT NOT NULL,
+                    PRIMARY KEY (organization_id, project_id),
+                    FOREIGN KEY (organization_id) REFERENCES organizations(id)
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_prospects_org ON prospects(organization_id);
+                CREATE INDEX IF NOT EXISTS idx_prospects_stage ON prospects(stage);
+                CREATE INDEX IF NOT EXISTS idx_org_projects_org ON organization_projects(organization_id);
+                CREATE INDEX IF NOT EXISTS idx_org_projects_proj ON organization_projects(project_id);
+
+                DELETE FROM schema_version;
+                INSERT INTO schema_version (version) VALUES (2);
+
+                COMMIT;",
+            )
+            .context("Failed to initialize schema")?;
+    } else if version < 2 {
+        // Upgrade existing v1 database: add new columns
+        self.conn
+            .execute_batch(
+                "BEGIN TRANSACTION;
+                ALTER TABLE prospects ADD COLUMN source_url TEXT;
+                ALTER TABLE prospects ADD COLUMN closing_date TEXT;
+                ALTER TABLE organizations ADD COLUMN notes TEXT;
+                DELETE FROM schema_version;
+                INSERT INTO schema_version (version) VALUES (2);
+                COMMIT;",
+            )
+            .context("Failed to migrate schema to v2")?;
+    }
+
+    Ok(())
+}
+```
+
+**Step 5: Update `upsert_prospect` to include new fields**
+
+Replace the `upsert_prospect` method:
+
+```rust
+pub fn upsert_prospect(&self, prospect: &Prospect) -> Result<()> {
+    let stage_str = serde_json::to_string(&prospect.stage)?;
+
+    self.conn.execute(
+        "INSERT INTO prospects (id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, source_url, closing_date, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+         ON CONFLICT(id) DO UPDATE SET
+            name = excluded.name,
+            description = excluded.description,
+            stage = excluded.stage,
+            value = excluded.value,
+            contact_name = excluded.contact_name,
+            contact_email = excluded.contact_email,
+            contact_role = excluded.contact_role,
+            source_url = excluded.source_url,
+            closing_date = excluded.closing_date,
+            updated_at = excluded.updated_at",
+        params![
+            prospect.id,
+            prospect.organization_id,
+            prospect.name,
+            prospect.description,
+            stage_str,
+            prospect.value,
+            prospect.contact_name,
+            prospect.contact_email,
+            prospect.contact_role,
+            prospect.source_url,
+            prospect.closing_date,
+            prospect.created_at,
+            prospect.updated_at,
+        ],
+    )?;
+    Ok(())
+}
+```
+
+**Step 6: Update `list_prospects` to read new fields**
+
+Replace `list_prospects`:
+
+```rust
+pub fn list_prospects(&self, organization_id: &str) -> Result<Vec<Prospect>> {
+    let mut stmt = self.conn.prepare(
+        "SELECT id, organization_id, name, description, stage, value, contact_name, contact_email, contact_role, source_url, closing_date, created_at, updated_at
+         FROM prospects WHERE organization_id = ?1 ORDER BY created_at",
+    )?;
+
+    let prospects = stmt
+        .query_map([organization_id], |row| {
+            let stage_str: String = row.get(4)?;
+            let stage = match serde_json::from_str(&stage_str) {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        "Invalid prospect stage '{}' in database, defaulting to Lead: {}",
+                        stage_str,
+                        e
+                    );
+                    ProspectStage::Lead
+                }
+            };
+            Ok(Prospect {
+                id: row.get(0)?,
+                organization_id: row.get(1)?,
+                name: row.get(2)?,
+                description: row.get(3)?,
+                stage,
+                value: row.get(5)?,
+                contact_name: row.get(6)?,
+                contact_email: row.get(7)?,
+                contact_role: row.get(8)?,
+                source_url: row.get(9)?,
+                closing_date: row.get(10)?,
+                created_at: row.get(11)?,
+                updated_at: row.get(12)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(prospects)
+}
+```
+
+**Step 7: Add org notes methods to `OrganizationStore`**
+
+Add after `delete_organization`:
+
+```rust
+/// Get the notes for an organization. Returns empty string if none.
+pub fn get_org_notes(&self, org_id: &str) -> Result<String> {
+    let notes: Option<String> = self
+        .conn
+        .query_row(
+            "SELECT notes FROM organizations WHERE id = ?1",
+            [org_id],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten();
+    Ok(notes.unwrap_or_default())
+}
+
+/// Set the notes for an organization.
+pub fn set_org_notes(&self, org_id: &str, notes: &str) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    self.conn.execute(
+        "UPDATE organizations SET notes = ?1, updated_at = ?2 WHERE id = ?3",
+        params![notes, now, org_id],
+    )?;
+    Ok(())
+}
+```
+
+**Step 8: Fix existing tests — add `source_url: None, closing_date: None` to Prospect constructions**
+
+In `store.rs` tests, each `Prospect { ... }` struct literal needs two new fields:
+
+```rust
+source_url: None,
+closing_date: None,
+```
+
+Add these to every `Prospect { ... }` construction in the test module (search for `stage: ProspectStage` to find them all).
+
+**Step 9: Run all tests to verify they pass**
+
+```bash
+cargo test -p myme-organizations 2>&1 | tail -20
+```
+
+Expected: all tests pass including the three new ones.
+
+**Step 10: Commit**
+
+```bash
+git add crates/myme-organizations/
+git commit -m "feat(organizations): add source_url, closing_date to Prospect; org notes; schema v2"
+```
+
+---
+
+### Task 2: Update northcloud `build_rfp_description` — remove embedded source/closing
+
+**Files:**
+- Modify: `crates/myme-integrations/src/northcloud.rs`
+
+**Step 1: Update failing test for `build_rfp_description`**
+
+The existing test `build_rfp_description_all_fields` asserts that "Source: ..." and "Closing: ..." are in the output. Change it to assert they are NOT:
+
+```rust
+#[test]
+fn build_rfp_description_all_fields() {
+    let rfp = RfpData {
+        organization_name: Some("City of Ottawa".into()),
+        description: Some("Web dev project".into()),
+        closing_date: Some("2026-04-01".into()),
+        city: Some("Ottawa".into()),
+        ..Default::default()
+    };
+    let result = build_rfp_description(&rfp);
+    assert!(result.contains("Issuer: City of Ottawa"));
+    assert!(result.contains("Web dev project"));
+    assert!(result.contains("Location: Ottawa"));
+    // closing date and source URL now live in dedicated Prospect fields
+    assert!(!result.contains("Closing:"));
+    assert!(!result.contains("Source:"));
+}
+
+#[test]
+fn build_rfp_description_minimal() {
+    let rfp = RfpData::default();
+    let result = build_rfp_description(&rfp);
+    assert_eq!(result, "");
+}
+
+#[test]
+fn build_rfp_description_empty_org_skipped() {
+    let rfp = RfpData {
+        organization_name: Some(String::new()),
+        description: Some("A project".into()),
+        ..Default::default()
+    };
+    let result = build_rfp_description(&rfp);
+    assert!(!result.contains("Issuer:"));
+    assert!(result.contains("A project"));
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p myme-integrations -- build_rfp_description 2>&1 | tail -10
+```
+
+Expected: FAIL — current function includes "Closing:" and "Source:".
+
+**Step 3: Rewrite `build_rfp_description`**
+
+Replace the public function (no longer takes a `url` parameter):
+
+```rust
+/// Build a multi-line prospect description from RFP metadata.
+/// Does NOT include closing_date or source_url — those live in dedicated Prospect fields.
+pub fn build_rfp_description(rfp: &RfpData) -> String {
+    let mut parts = Vec::new();
+    if let Some(org) = &rfp.organization_name {
+        if !org.is_empty() {
+            parts.push(format!("Issuer: {}", org));
+        }
+    }
+    if let Some(desc) = &rfp.description {
+        if !desc.is_empty() {
+            parts.push(desc.clone());
+        }
+    }
+    if let Some(city) = &rfp.city {
+        if !city.is_empty() {
+            parts.push(format!("Location: {}", city));
+        }
+    }
+    parts.join("\n")
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+cargo test -p myme-integrations 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+**Step 5: Commit**
+
+```bash
+git add crates/myme-integrations/src/northcloud.rs
+git commit -m "fix(integrations): remove source_url and closing_date from RFP description text"
+```
+
+---
+
+### Task 3: Populate new Prospect fields in the import service
+
+**Files:**
+- Modify: `crates/myme-ui/src/services/organization_service.rs`
+
+**Step 1: Update `do_import_rfp_leads` to pass new fields**
+
+The `build_rfp_description` call no longer takes `url`. The `Prospect` construction needs `source_url` and `closing_date`.
+
+Find the `Prospect { ... }` construction (around line 140) and replace it:
+
+```rust
+let description = if let Some(r) = rfp {
+    build_rfp_description(r)
+} else {
+    hit.snippet.clone().unwrap_or_default()
+};
+
+let source_url = Some(hit.url.clone());
+let closing_date = rfp.and_then(|r| r.closing_date.clone());
+
+let prospect = Prospect {
+    id: format!("nc-{}", hit.id),
+    organization_id: org_id.to_string(),
+    name,
+    description: if description.is_empty() { None } else { Some(description) },
+    stage: ProspectStage::Lead,
+    value: if value.is_empty() { None } else { Some(value) },
+    contact_name: if contact_name.is_empty() { None } else { Some(contact_name) },
+    contact_email: if contact_email.is_empty() { None } else { Some(contact_email) },
+    contact_role: None,
+    source_url,
+    closing_date,
+    created_at: now.clone(),
+    updated_at: now.clone(),
+};
+```
+
+Also remove the old non-rfp description branch that embedded "Source: ..." — replace it with just the snippet.
+
+**Step 2: Fix `create_prospect` in `prospect_model.rs`**
+
+In `crates/myme-ui/src/models/prospect_model.rs`, find the `Prospect { ... }` construction in `create_prospect` and add:
+
+```rust
+source_url: None,
+closing_date: None,
+```
+
+**Step 3: Fix `update_prospect` in `prospect_model.rs`**
+
+In `update_prospect`, find the `Prospect { ... }` construction and preserve the existing values:
+
+```rust
+source_url: existing.source_url.clone(),
+closing_date: existing.closing_date.clone(),
+```
+
+**Step 4: Build to catch any remaining compilation errors**
+
+```bash
+cargo build -p myme-ui 2>&1 | grep "^error" | head -20
+```
+
+Fix any remaining `Prospect { ... }` struct constructions missing the new fields.
+
+**Step 5: Run full test suite**
+
+```bash
+cargo test -p myme-core -p myme-integrations -p myme-organizations 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/myme-ui/src/
+git commit -m "feat(organizations): populate source_url and closing_date from RFP import"
+```
+
+---
+
+### Task 4: New ProspectModel bridge invokables
+
+**Files:**
+- Modify: `crates/myme-ui/src/models/prospect_model.rs`
+
+**Step 1: Add invokable declarations to the bridge**
+
+In the `extern "RustQt"` block, after `get_prospect_created_at`:
+
+```rust
+#[qinvokable]
+fn get_prospect_source_url(self: &ProspectModel, index: i32) -> QString;
+
+#[qinvokable]
+fn get_prospect_closing_date(self: &ProspectModel, index: i32) -> QString;
+
+/// Returns JSON array of indices for Lead prospects sorted by closing_date ascending (nulls last).
+#[qinvokable]
+fn lead_prospects_by_urgency(self: &ProspectModel) -> QString;
+
+/// Get notes for the current organization.
+#[qinvokable]
+fn get_org_notes(self: &ProspectModel) -> QString;
+
+/// Save notes for the current organization.
+#[qinvokable]
+fn set_org_notes(self: Pin<&mut ProspectModel>, notes: &QString);
+```
+
+**Step 2: Implement the new methods**
+
+Add after `get_prospect_created_at`:
+
+```rust
+pub fn get_prospect_source_url(&self, index: i32) -> QString {
+    self.rust()
+        .get_prospect(index)
+        .and_then(|p| p.source_url.as_ref())
+        .map(|u| QString::from(u))
+        .unwrap_or_else(|| QString::from(""))
+}
+
+pub fn get_prospect_closing_date(&self, index: i32) -> QString {
+    self.rust()
+        .get_prospect(index)
+        .and_then(|p| p.closing_date.as_ref())
+        .map(|d| QString::from(d))
+        .unwrap_or_else(|| QString::from(""))
+}
+
+pub fn lead_prospects_by_urgency(&self) -> QString {
+    let mut lead_indices: Vec<(usize, Option<String>)> = self
+        .rust()
+        .prospects
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.stage == ProspectStage::Lead)
+        .map(|(i, p)| (i, p.closing_date.clone()))
+        .collect();
+
+    lead_indices.sort_by(|(_, a_date), (_, b_date)| match (a_date, b_date) {
+        (Some(a), Some(b)) => a.cmp(b),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+
+    let indices: Vec<i32> = lead_indices.into_iter().map(|(i, _)| i as i32).collect();
+    let json = serde_json::to_string(&indices).unwrap_or_else(|_| "[]".to_string());
+    QString::from(&json)
+}
+
+pub fn get_org_notes(&self) -> QString {
+    let org_id = self.rust().organization_id.to_string();
+    if org_id.is_empty() {
+        return QString::from("");
+    }
+    let store = match &self.rust().organization_store {
+        Some(s) => s,
+        None => return QString::from(""),
+    };
+    match store.lock().get_org_notes(&org_id) {
+        Ok(notes) => QString::from(notes),
+        Err(e) => {
+            tracing::error!("Failed to get org notes: {}", e);
+            QString::from("")
+        }
+    }
+}
+
+pub fn set_org_notes(mut self: Pin<&mut Self>, notes: &QString) {
+    let org_id = self.as_ref().rust().organization_id.to_string();
+    if org_id.is_empty() {
+        return;
+    }
+    let store = match &self.as_ref().rust().organization_store {
+        Some(s) => s.clone(),
+        None => return,
+    };
+    if let Err(e) = store.lock().set_org_notes(&org_id, &notes.to_string()) {
+        tracing::error!("Failed to save org notes: {}", e);
+        self.as_mut().set_error_message(QString::from(format!("Failed to save notes: {}", e)));
+    }
+}
+```
+
+**Step 3: Build**
+
+```bash
+cargo build -p myme-ui 2>&1 | grep "^error" | head -20
+```
+
+Expected: clean build.
+
+**Step 4: Commit**
+
+```bash
+git add crates/myme-ui/src/models/prospect_model.rs
+git commit -m "feat(ui-bridge): add source_url, closing_date, urgency sort, org notes invokables"
+```
+
+---
+
+### Task 5: QML — Lead column triage redesign
+
+**Files:**
+- Modify: `crates/myme-ui/qml/pages/OrganizationDetailPage.qml`
+
+**Step 1: Add page-level properties and helper functions**
+
+Near the top of the `Page { ... }` body (after existing property declarations), add:
+
+```qml
+property int selectedProspectIndex: -1
+
+// Urgency helpers
+function daysUntil(dateStr) {
+    if (!dateStr || dateStr === "") return -1
+    var parts = dateStr.split("-")
+    if (parts.length < 3) return -1
+    var d = new Date(parts[0], parts[1] - 1, parts[2])
+    var today = new Date()
+    today.setHours(0, 0, 0, 0)
+    return Math.ceil((d - today) / 86400000)
+}
+
+function urgencyColor(days) {
+    if (days < 0) return Theme.textSecondary
+    if (days <= 7) return "#E57373"
+    if (days <= 21) return "#FF8A65"
+    if (days <= 60) return "#F59E0B"
+    return Theme.textSecondary
+}
+
+function urgencyLabel(days) {
+    if (days < 0) return "Closed"
+    if (days === 0) return "Closes today"
+    if (days === 1) return "1 day left"
+    return days + " days left"
+}
+```
+
+**Step 2: Wrap kanban + side panel in a RowLayout**
+
+Find `ScrollView {` (the kanban scroll view, around line 267). It currently sits inside a `ColumnLayout`. Replace that `ScrollView` with a `RowLayout` that holds the scroll view and the side panel sibling:
+
+```qml
+RowLayout {
+    Layout.fillWidth: true
+    Layout.fillHeight: true
+    spacing: 0
+
+    // Kanban scroll area
+    ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.leftMargin: Theme.spacingMd
+        Layout.rightMargin: selectedProspectIndex >= 0 ? 0 : Theme.spacingMd
+        Layout.bottomMargin: Theme.spacingMd
+        contentWidth: pipelineRow.implicitWidth
+        clip: true
+
+        RowLayout {
+            id: pipelineRow
+            spacing: Theme.spacingSm
+            height: parent.height
+
+            Repeater {
+                model: detailPage.stages
+                // ... existing column contents (see Step 3)
+            }
+        }
+    }
+
+    // Side panel
+    Rectangle {
+        id: sidePanel
+        Layout.preferredWidth: 380
+        Layout.fillHeight: true
+        visible: selectedProspectIndex >= 0
+        color: Theme.isDark ? "#0affffff" : "#08000000"
+        border.color: Theme.borderLight
+        border.width: 1
+
+        // Contents added in Task 6
+    }
+}
+```
+
+**Step 3: Redesign the Lead column**
+
+Inside the `Repeater { model: detailPage.stages }`, find the inner `ListView` delegate. The `model:` binding needs to use urgency-sorted indices for Lead:
+
+```qml
+model: {
+    void(prospectModel.prospect_revision);
+    if (modelData.key === "lead") {
+        return JSON.parse(prospectModel.lead_prospects_by_urgency());
+    }
+    return JSON.parse(prospectModel.prospects_for_stage(modelData.key));
+}
+```
+
+The stage column width should be wider for Lead:
+
+```qml
+Layout.preferredWidth: modelData.key === "lead" ? 320 : 220
+```
+
+**Step 4: Redesign the Lead card delegate**
+
+Inside the `delegate: Rectangle { ... }` for prospect cards, replace the `ColumnLayout` content with a conditional that gives Lead cards a richer layout:
+
+```qml
+ColumnLayout {
+    id: prospectCardLayout
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.top: parent.top
+    anchors.margins: Theme.spacingSm
+    spacing: 4
+
+    // Urgency + budget row (Lead only)
+    RowLayout {
+        visible: modelData_stage === "lead"
+        Layout.fillWidth: true
+        spacing: Theme.spacingXs
+
+        property string modelData_stage: modelData  // bind before Repeater context changes
+        // Note: inside the ListView delegate, modelData is the index (i32).
+        // We read stage from the model via get_prospect_stage.
+        // Use the outer stage key from the Repeater context captured by the parent Rectangle.
+    }
+    // ...
+}
+```
+
+Wait — the delegate is inside a `Repeater` whose `modelData` is the prospect index (i32). The outer stage key is `modelData.key` from the outer `Repeater`. Inside a nested `Repeater`, the outer modelData is shadowed. We need to capture the outer stage key.
+
+Replace the `// Stage column` `Rectangle` with this pattern to capture the stage key:
+
+```qml
+Rectangle {
+    id: stageColumn
+    Layout.preferredWidth: modelData.key === "lead" ? 320 : 220
+    Layout.fillHeight: true
+    color: Theme.isDark ? "#05ffffff" : "#03000000"
+    radius: Theme.cardRadius
+    border.color: Theme.cardBorderSubtle
+    border.width: 1
+
+    property string stageKey: modelData.key   // capture before inner Repeater shadows modelData
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Theme.spacingSm
+        spacing: Theme.spacingSm
+
+        // Stage header (unchanged)
+        RowLayout { ... }
+
+        // Prospect cards
+        ListView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+            spacing: Theme.spacingXs
+
+            model: {
+                void(prospectModel.prospect_revision);
+                if (stageColumn.stageKey === "lead") {
+                    return JSON.parse(prospectModel.lead_prospects_by_urgency());
+                }
+                return JSON.parse(prospectModel.prospects_for_stage(stageColumn.stageKey));
+            }
+
+            delegate: Rectangle {
+                id: prospectCard
+                width: ListView.view.width
+                height: cardContent.implicitHeight + Theme.spacingSm * 2
+                radius: Theme.buttonRadius
+                color: (detailPage.selectedProspectIndex === prospectIndex)
+                    ? (Theme.isDark ? "#20ffffff" : "#10000000")
+                    : (prospectMouse.containsMouse
+                        ? (Theme.isDark ? Qt.lighter(Theme.cardBg, 1.05) : Qt.darker(Theme.cardBg, 1.02))
+                        : Theme.cardBg)
+                border.color: (detailPage.selectedProspectIndex === prospectIndex)
+                    ? Theme.primary
+                    : Theme.cardBorderSubtle
+                border.width: 1
+
+                property int prospectIndex: modelData
+                property bool isLead: stageColumn.stageKey === "lead"
+
+                opacity: 0
+                Component.onCompleted: prospectFade.start()
+                SequentialAnimation {
+                    id: prospectFade
+                    PauseAnimation { duration: index * 30 }
+                    NumberAnimation { target: prospectCard; property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
+                }
+
+                ColumnLayout {
+                    id: cardContent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.margins: Theme.spacingSm
+                    spacing: 4
+
+                    // --- Lead-specific urgency + budget row ---
+                    RowLayout {
+                        visible: prospectCard.isLead
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingXs
+
+                        property int days: detailPage.daysUntil(prospectModel.get_prospect_closing_date(prospectIndex))
+
+                        Rectangle {
+                            visible: parent.days >= 0
+                            radius: 3
+                            color: Qt.rgba(0, 0, 0, 0)
+                            implicitHeight: urgencyText.implicitHeight + 4
+                            implicitWidth: urgencyText.implicitWidth + 8
+
+                            Label {
+                                id: urgencyText
+                                anchors.centerIn: parent
+                                text: detailPage.urgencyLabel(parent.parent.days)
+                                font.family: Theme.fontFamily
+                                font.pixelSize: 10
+                                font.weight: Font.Medium
+                                color: detailPage.urgencyColor(parent.parent.days)
+                            }
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        Label {
+                            visible: text !== ""
+                            text: prospectModel.get_prospect_value(prospectIndex)
+                            font.family: Theme.fontFamily
+                            font.pixelSize: 10
+                            font.weight: Font.Medium
+                            color: Theme.primary
+                        }
+                    }
+
+                    // --- Name (2 lines for Lead, 1 for others) ---
+                    Label {
+                        text: prospectModel.get_prospect_name(prospectIndex)
+                        font.family: Theme.fontFamily
+                        font.pixelSize: Theme.fontSizeSmall
+                        font.weight: Font.Medium
+                        color: Theme.text
+                        elide: Text.ElideRight
+                        maximumLineCount: prospectCard.isLead ? 2 : 1
+                        wrapMode: prospectCard.isLead ? Text.WordWrap : Text.NoWrap
+                        Layout.fillWidth: true
+                    }
+
+                    // --- Contact / org name ---
+                    Label {
+                        visible: text !== ""
+                        text: prospectModel.get_prospect_contact_name(prospectIndex)
+                        font.family: Theme.fontFamily
+                        font.pixelSize: 11
+                        color: Theme.textSecondary
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+
+                    // --- Lead quick-action buttons ---
+                    RowLayout {
+                        visible: prospectCard.isLead && prospectMouse.containsMouse
+                        Layout.fillWidth: true
+                        spacing: Theme.spacingXs
+
+                        // Open RFP
+                        Button {
+                            text: "🔗 Open RFP"
+                            visible: prospectModel.get_prospect_source_url(prospectIndex) !== ""
+                            font.family: Theme.fontFamily
+                            font.pixelSize: 10
+                            contentItem: Label { text: parent.text; font: parent.font; color: Theme.primary; horizontalAlignment: Text.AlignHCenter }
+                            background: Rectangle {
+                                color: parent.hovered ? (Theme.isDark ? "#15ffffff" : "#08000000") : "transparent"
+                                radius: Theme.buttonRadius
+                                border.color: Theme.isDark ? "#15ffffff" : "#10000000"
+                                border.width: 1
+                                implicitHeight: 24
+                            }
+                            onClicked: Qt.openUrlExternally(prospectModel.get_prospect_source_url(prospectIndex))
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        // Qualify
+                        Button {
+                            text: "✓ Qualify"
+                            font.family: Theme.fontFamily
+                            font.pixelSize: 10
+                            contentItem: Label { text: parent.text; font: parent.font; color: "#5BB98C"; horizontalAlignment: Text.AlignHCenter }
+                            background: Rectangle {
+                                color: parent.hovered ? "#155BB98C" : "transparent"
+                                radius: Theme.buttonRadius
+                                border.color: "#305BB98C"
+                                border.width: 1
+                                implicitHeight: 24
+                                implicitWidth: 62
+                            }
+                            onClicked: {
+                                if (detailPage.selectedProspectIndex === prospectIndex) {
+                                    detailPage.selectedProspectIndex = -1;
+                                }
+                                prospectModel.move_prospect(prospectIndex, "qualified");
+                            }
+                        }
+
+                        // Skip
+                        Button {
+                            text: "✗ Skip"
+                            font.family: Theme.fontFamily
+                            font.pixelSize: 10
+                            contentItem: Label { text: parent.text; font: parent.font; color: "#E57373"; horizontalAlignment: Text.AlignHCenter }
+                            background: Rectangle {
+                                color: parent.hovered ? "#15E57373" : "transparent"
+                                radius: Theme.buttonRadius
+                                border.color: "#30E57373"
+                                border.width: 1
+                                implicitHeight: 24
+                                implicitWidth: 50
+                            }
+                            onClicked: {
+                                if (detailPage.selectedProspectIndex === prospectIndex) {
+                                    detailPage.selectedProspectIndex = -1;
+                                }
+                                prospectModel.move_prospect(prospectIndex, "lost");
+                            }
+                        }
+                    }
+                }
+
+                MouseArea {
+                    id: prospectMouse
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: {
+                        if (detailPage.selectedProspectIndex === prospectIndex) {
+                            detailPage.selectedProspectIndex = -1;
+                        } else {
+                            detailPage.selectedProspectIndex = prospectIndex;
+                        }
+                    }
+                }
+            }
+        }
+
+        // + Add button (unchanged)
+        Button { ... }
+    }
+}
+```
+
+**Step 5: Test manually**
+
+```bash
+task run
+```
+
+1. Navigate to Web Networks → Pipeline
+2. Lead column should be wider, cards show urgency badges
+3. Hover a Lead card — "🔗 Open RFP", "✓ Qualify", "✗ Skip" buttons appear
+4. Click "✓ Qualify" — card moves to Qualified column
+5. Click "✗ Skip" — card disappears from Lead
+
+**Step 6: Commit**
+
+```bash
+git add crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+git commit -m "feat(ui): lead triage redesign — urgency badges, wider column, quick-action buttons"
+```
+
+---
+
+### Task 6: QML — Prospect side panel
+
+**Files:**
+- Modify: `crates/myme-ui/qml/pages/OrganizationDetailPage.qml`
+
+**Step 1: Add Escape key handler to the page**
+
+After the existing `Component.onCompleted`, add:
+
+```qml
+Keys.onEscapePressed: selectedProspectIndex = -1
+focus: true
+```
+
+**Step 2: Implement the side panel Rectangle content**
+
+Replace the `// Contents added in Task 6` placeholder in `sidePanel`:
+
+```qml
+Rectangle {
+    id: sidePanel
+    Layout.preferredWidth: 380
+    Layout.fillHeight: true
+    visible: selectedProspectIndex >= 0
+    color: Theme.isDark ? "#0affffff" : "#06000000"
+    border.color: Theme.borderLight
+    border.width: 1
+
+    // Slide-in animation
+    opacity: selectedProspectIndex >= 0 ? 1 : 0
+    Behavior on opacity { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Theme.spacingMd
+        spacing: Theme.spacingMd
+        visible: detailPage.selectedProspectIndex >= 0
+
+        // Close button
+        RowLayout {
+            Layout.fillWidth: true
+
+            Label {
+                text: prospectModel.get_prospect_name(detailPage.selectedProspectIndex)
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeNormal
+                font.weight: Font.Bold
+                color: Theme.text
+                wrapMode: Text.WordWrap
+                maximumLineCount: 2
+                elide: Text.ElideRight
+                Layout.fillWidth: true
+            }
+
+            Button {
+                contentItem: Text {
+                    text: Icons.x
+                    font.family: Icons.family
+                    font.pixelSize: 16
+                    color: Theme.textSecondary
+                    horizontalAlignment: Text.AlignHCenter
+                }
+                background: Rectangle {
+                    color: parent.hovered ? (Theme.isDark ? "#10ffffff" : "#08000000") : "transparent"
+                    radius: Theme.buttonRadius
+                    implicitWidth: 28
+                    implicitHeight: 28
+                }
+                onClicked: detailPage.selectedProspectIndex = -1
+            }
+        }
+
+        // Stage selector
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+
+            Label {
+                text: "Stage"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.textSecondary
+                Layout.preferredWidth: 70
+            }
+
+            ComboBox {
+                id: stageCombo
+                Layout.fillWidth: true
+                model: ["Lead", "Qualified", "Contacted", "Proposal", "Negotiation", "Won", "Lost"]
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+
+                // Sync to selected prospect
+                currentIndex: {
+                    var s = prospectModel.get_prospect_stage(detailPage.selectedProspectIndex)
+                    return Math.max(0, model.indexOf(s))
+                }
+
+                contentItem: Label {
+                    leftPadding: 8
+                    text: stageCombo.displayText
+                    font: stageCombo.font
+                    color: Theme.text
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                background: Rectangle {
+                    color: Theme.surfaceAlt
+                    radius: Theme.buttonRadius
+                    border.color: stageCombo.popup.visible ? Theme.primary : Theme.borderLight
+                    border.width: 1
+                    implicitHeight: 32
+                }
+
+                onActivated: {
+                    var stageKey = currentText.toLowerCase()
+                    prospectModel.move_prospect(detailPage.selectedProspectIndex, stageKey)
+                }
+            }
+        }
+
+        // Closing date with urgency
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+            visible: prospectModel.get_prospect_closing_date(detailPage.selectedProspectIndex) !== ""
+
+            property string closingDate: prospectModel.get_prospect_closing_date(detailPage.selectedProspectIndex)
+            property int days: detailPage.daysUntil(closingDate)
+
+            Label {
+                text: "Closing"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.textSecondary
+                Layout.preferredWidth: 70
+            }
+
+            ColumnLayout {
+                spacing: 2
+                Label {
+                    text: parent.parent.closingDate
+                    font.family: Theme.fontFamily
+                    font.pixelSize: Theme.fontSizeSmall
+                    color: Theme.text
+                }
+                Label {
+                    visible: parent.parent.days >= 0
+                    text: "● " + detailPage.urgencyLabel(parent.parent.days)
+                    font.family: Theme.fontFamily
+                    font.pixelSize: 11
+                    color: detailPage.urgencyColor(parent.parent.days)
+                }
+            }
+        }
+
+        // Budget / value
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+            visible: prospectModel.get_prospect_value(detailPage.selectedProspectIndex) !== ""
+
+            Label {
+                text: "Budget"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.textSecondary
+                Layout.preferredWidth: 70
+            }
+
+            Label {
+                text: prospectModel.get_prospect_value(detailPage.selectedProspectIndex)
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                font.weight: Font.Medium
+                color: Theme.primary
+            }
+        }
+
+        // Contact
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+            visible: prospectModel.get_prospect_contact_name(detailPage.selectedProspectIndex) !== ""
+
+            Label {
+                text: "Contact"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.textSecondary
+                Layout.preferredWidth: 70
+            }
+
+            Label {
+                text: prospectModel.get_prospect_contact_name(detailPage.selectedProspectIndex)
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.text
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+        }
+
+        // Email
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+            visible: prospectModel.get_prospect_contact_email(detailPage.selectedProspectIndex) !== ""
+
+            Label {
+                text: "Email"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.textSecondary
+                Layout.preferredWidth: 70
+            }
+
+            Label {
+                text: prospectModel.get_prospect_contact_email(detailPage.selectedProspectIndex)
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.primary
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+        }
+
+        // Open Source RFP button
+        Button {
+            visible: prospectModel.get_prospect_source_url(detailPage.selectedProspectIndex) !== ""
+            Layout.fillWidth: true
+            contentItem: Label {
+                text: "🔗  Open Source RFP →"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.primaryText
+                horizontalAlignment: Text.AlignHCenter
+            }
+            background: Rectangle {
+                color: parent.hovered ? Theme.primaryHover : Theme.primary
+                radius: Theme.buttonRadius
+                implicitHeight: 36
+            }
+            onClicked: Qt.openUrlExternally(prospectModel.get_prospect_source_url(detailPage.selectedProspectIndex))
+        }
+
+        // Description
+        Label {
+            visible: prospectModel.get_prospect_description(detailPage.selectedProspectIndex) !== ""
+            text: "Description"
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.fontSizeSmall
+            font.weight: Font.Bold
+            color: Theme.textSecondary
+        }
+
+        ScrollView {
+            visible: prospectModel.get_prospect_description(detailPage.selectedProspectIndex) !== ""
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            Label {
+                width: parent.width
+                text: prospectModel.get_prospect_description(detailPage.selectedProspectIndex)
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                color: Theme.text
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        // Edit + Delete row
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Theme.spacingSm
+
+            Button {
+                text: "Edit"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                contentItem: Label { text: parent.text; font: parent.font; color: Theme.primaryText; horizontalAlignment: Text.AlignHCenter }
+                background: Rectangle { color: parent.hovered ? Theme.primaryHover : Theme.primary; radius: Theme.buttonRadius; implicitHeight: 32; implicitWidth: 70 }
+                onClicked: {
+                    editProspectIndex = detailPage.selectedProspectIndex;
+                    editProspectDialog.open();
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Button {
+                text: "Delete"
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeSmall
+                contentItem: Label { text: parent.text; font: parent.font; color: "#E57373"; horizontalAlignment: Text.AlignHCenter }
+                background: Rectangle { color: parent.hovered ? "#20E57373" : "transparent"; radius: Theme.buttonRadius; implicitHeight: 32 }
+                onClicked: {
+                    prospectModel.delete_prospect(detailPage.selectedProspectIndex);
+                    detailPage.selectedProspectIndex = -1;
+                }
+            }
+        }
+    }
+}
+```
+
+**Step 3: Test manually**
+
+```bash
+task run
+```
+
+1. Click any prospect card (not an action button) → side panel slides in from right
+2. Kanban shrinks, panel shows at right
+3. Stage ComboBox shows current stage — change it → card moves in kanban
+4. "Open Source RFP →" button opens browser for RFP leads
+5. Urgency badge and budget visible for RFP leads
+6. Press Escape → panel closes
+7. Click same card again → panel closes
+
+**Step 4: Commit**
+
+```bash
+git add crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+git commit -m "feat(ui): prospect side panel with stage selector, source URL, urgency detail"
+```
+
+---
+
+### Task 7: QML — Notes tab persistence
+
+**Files:**
+- Modify: `crates/myme-ui/qml/pages/OrganizationDetailPage.qml`
+
+**Step 1: Update the Notes tab**
+
+Replace the entire Notes tab (Tab 2) `Item { id: notesTab ... }`:
+
+```qml
+Item {
+    id: notesTab
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: Theme.spacingLg
+        spacing: Theme.spacingSm
+
+        Label {
+            text: "Organization Notes"
+            font.family: Theme.fontFamily
+            font.pixelSize: Theme.fontSizeNormal
+            font.weight: Font.Bold
+            color: Theme.text
+        }
+
+        ScrollView {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            TextArea {
+                id: notesArea
+                font.family: Theme.fontFamily
+                font.pixelSize: Theme.fontSizeNormal
+                color: Theme.text
+                wrapMode: TextArea.Wrap
+                placeholderText: "Write notes about this organization..."
+
+                background: Rectangle {
+                    color: Theme.isDark ? "#05ffffff" : "#03000000"
+                    radius: Theme.cardRadius
+                    border.color: notesArea.activeFocus ? Theme.primary : (Theme.isDark ? "#10ffffff" : "#10000000")
+                    border.width: 1
+                }
+
+                onTextChanged: notesDebounce.restart()
+            }
+        }
+    }
+
+    Timer {
+        id: notesDebounce
+        interval: 500
+        repeat: false
+        onTriggered: prospectModel.set_org_notes(notesArea.text)
+    }
+}
+```
+
+**Step 2: Load notes when tab becomes active**
+
+Update the existing `onCurrentTabChanged` handler:
+
+```qml
+onCurrentTabChanged: {
+    prospectModel.import_result = ""
+    if (currentTab === 2) {
+        notesArea.text = prospectModel.get_org_notes()
+    }
+}
+```
+
+Also load notes on page open. Update `Component.onCompleted`:
+
+```qml
+Component.onCompleted: {
+    prospectModel.load_prospects(detailPage.organizationId);
+    notesArea.text = prospectModel.get_org_notes();
+}
+```
+
+**Step 3: Remove the "not saved" warning label**
+
+Delete the `Label { text: "Notes persistence coming soon..." }` — no longer accurate.
+
+**Step 4: Test manually**
+
+```bash
+task run
+```
+
+1. Go to Notes tab → type some text
+2. Wait 500ms → text auto-saves (no UI feedback needed)
+3. Navigate away to another org, come back → notes reload
+4. Restart the app → notes persist
+
+**Step 5: Run full test suite**
+
+```bash
+cargo test -p myme-core -p myme-integrations -p myme-organizations 2>&1 | tail -10
+```
+
+Expected: all pass.
+
+**Step 6: Commit**
+
+```bash
+git add crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+git commit -m "feat(ui): org notes tab persistence via prospectModel invokables"
+```
+
+---
+
+## Summary of all changes
+
+| File | Change |
+|---|---|
+| `myme-organizations/src/models.rs` | `source_url`, `closing_date` on `Prospect` |
+| `myme-organizations/src/store.rs` | Schema v2 migration, updated SQL, `get/set_org_notes` |
+| `myme-integrations/src/northcloud.rs` | `build_rfp_description` removes embedded source/closing |
+| `myme-ui/src/services/organization_service.rs` | Populate `source_url`, `closing_date` in import |
+| `myme-ui/src/models/prospect_model.rs` | 5 new invokables, `source_url`/`closing_date` in CRUD |
+| `myme-ui/qml/pages/OrganizationDetailPage.qml` | Lead triage, side panel, notes persistence |


### PR DESCRIPTION
## Summary

- **DB schema v2**: adds `source_url` and `closing_date` to `prospects`, `notes` to `organizations`, with safe ALTER TABLE migration for existing databases
- **RFP import**: populates `source_url`/`closing_date` from NorthCloud hits instead of embedding them in description text
- **Rust bridge**: 5 new invokables on `ProspectModel` — `get_prospect_source_url`, `get_prospect_closing_date`, `lead_prospects_by_urgency` (sorted by closing date), `get_org_notes`, `set_org_notes`
- **Lead column redesign**: 320px wide (vs 220px), sorted by urgency, cards show days-left badge (red/orange/yellow) + budget; hover reveals Open RFP / ✓ Qualify / ✗ Skip action buttons
- **Prospect side panel**: 380px slide-in panel on card click — stage ComboBox (saves immediately), closing date + urgency, budget, contact, Open Source RFP CTA, Edit/Delete; closes on Escape
- **Notes persistence**: org notes TextArea auto-saves via 500ms debounce; loads on tab open and page load

## Test Plan

- [ ] Run `task run` → navigate to Web Networks → Pipeline
- [ ] Lead column is wider, cards show urgency badges (red/orange/yellow) and budget
- [ ] Hover a Lead card → Open RFP, ✓ Qualify, ✗ Skip buttons appear
- [ ] Click Open RFP → opens browser
- [ ] Click ✓ Qualify → card moves to Qualified column
- [ ] Click ✗ Skip → card disappears from Lead
- [ ] Click a card → side panel slides in from right
- [ ] Change stage in ComboBox → card moves in kanban
- [ ] Press Escape → panel closes
- [ ] Go to Notes tab → type text → navigate away → return → notes reload
- [ ] Restart app → notes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)