### PR TITLE
fix(pipeline): remaining review fixes — logging, error messages, NaN guard

### DIFF
--- a/crates/myme-organizations/src/store.rs
+++ b/crates/myme-organizations/src/store.rs
@@ -694,6 +694,15 @@ mod tests {
     }
 
     #[test]
+    fn test_set_org_notes_nonexistent_org_errors() {
+        let (store, _dir) = test_store();
+        let result = store.set_org_notes("no-such-org", "some notes");
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("no organization found"), "Expected 'no organization found' in: {}", msg);
+    }
+
+    #[test]
     fn test_fresh_db_initialises_at_v2() {
         // Verifies that a fresh store lands on v2 and has the new columns
         let (store, _dir) = test_store();

--- a/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
+++ b/crates/myme-ui/qml/pages/OrganizationDetailPage.qml
@@ -23,6 +23,7 @@ Page {
         var parts = dateStr.split("-")
         if (parts.length < 3) return -1
         var d = new Date(parts[0], parts[1] - 1, parts[2])
+        if (isNaN(d.getTime())) return -1
         var today = new Date()
         today.setHours(0, 0, 0, 0)
         return Math.ceil((d - today) / 86400000)
@@ -1484,6 +1485,5 @@ Page {
 
     Component.onCompleted: {
         prospectModel.load_prospects(detailPage.organizationId);
-        notesArea.text = prospectModel.get_org_notes()
     }
 }

--- a/crates/myme-ui/src/models/prospect_model.rs
+++ b/crates/myme-ui/src/models/prospect_model.rs
@@ -356,7 +356,8 @@ impl qobject::ProspectModel {
         };
         if let Err(e) = store.lock().set_org_notes(&org_id, &notes.to_string()) {
             tracing::error!("Failed to save org notes: {}", e);
-            self.as_mut().set_error_message(QString::from(format!("Failed to save notes: {}", e)));
+            self.as_mut()
+                .set_error_message(QString::from(myme_core::AppError::from(e).user_message()));
         }
     }
 
@@ -586,7 +587,10 @@ impl qobject::ProspectModel {
         }
         let store = match &self.rust().organization_store {
             Some(s) => s,
-            None => return QString::from("[]"),
+            None => {
+                tracing::warn!("linked_projects: store not initialized");
+                return QString::from("[]");
+            }
         };
         let store_guard = store.lock();
         match store_guard.list_linked_projects(&org_id) {


### PR DESCRIPTION
## Summary

Remaining issues from the PR #35 review that weren't covered by #34:

- `linked_projects` silently returned `[]` when the store was not initialized — add `tracing::warn!`
- `set_org_notes` error message exposed a raw Rust error string to the UI — use `AppError::user_message()` for consistency with all other methods
- `Component.onCompleted` called `get_org_notes()` redundantly on page load; notes are correctly loaded by `onCurrentTabChanged` when the Notes tab is selected
- `daysUntil()` could propagate NaN for malformed date strings — add `isNaN(d.getTime())` guard returning -1
- New test: `test_set_org_notes_nonexistent_org_errors` verifies the rows-affected guard (added in #34) produces a clear diagnostic message

## Test plan

- [ ] `cargo test -p myme-organizations` — 24 tests pass including the new one
- [ ] Notes tab loads correctly when first navigated to
- [ ] Urgency badges handle malformed closing dates gracefully (no NaN displayed)